### PR TITLE
fix(tooling): change readme hack to prevent npm from pointing latest at a canary release

### DIFF
--- a/tooling/circle-scripts/publish.sh
+++ b/tooling/circle-scripts/publish.sh
@@ -51,5 +51,5 @@ echo "Tricking npm website into updating the README"
 # See https://github.com/npm/newww/issues/389#issuecomment-188428605 and
 # https://github.com/lerna/lerna/issues/64 for details
 npm run lerna -- exec --scope ciscospark -- npm version --no-git-tag-version "${NEW_VERSION}-readmehack"
-npm run lerna -- exec --scope ciscospark -- npm publish
+npm run lerna -- exec --scope ciscospark -- npm publish --tag=readmehack
 npm run lerna -- exec --scope ciscospark -- npm unpublish ciscospark@"${NEW_VERSION}-readmehack"

--- a/tooling/jenkins-scripts/gate-jenkins.sh
+++ b/tooling/jenkins-scripts/gate-jenkins.sh
@@ -13,6 +13,15 @@ export XUNIT=true
 LOG_FILE="$(pwd)/test.log"
 rm -f "${LOG_FILE}"
 
+PWD=`pwd`
+
+cd /tmp
+ls lerna > /dev/null 2> /dev/null || git clone git@github.com:ianwremmel/lerna.git:
+git checkout de0f7f2
+npm link
+cd pwd
+npm link lerna
+
 # INSTALL
 echo "Installing modular SDK dependencies"
 npm run bootstrap


### PR DESCRIPTION
Fixes #12