### PR TITLE
use trace only on node 6 and up as it does not work for node v5

### DIFF
--- a/Gruntfile.package.js
+++ b/Gruntfile.package.js
@@ -388,7 +388,7 @@ module.exports = function(grunt) {
       ]);
     }
 
-    if (parseInt(process.versions.node.split('.')[0]) < 5) {
+    if (parseInt(process.versions.node.split('.')[0]) <= 5) {
       return requires.concat([
         'clarify',
         function() {


### PR DESCRIPTION
Fixes #30 
Trace only works on 4.5 or 6
https://github.com/AndreasMadsen/trace/blob/6bd45f36f8413ba64a436cf5e6df13c381fa043e/package.json#L36