### PR TITLE
Disable canary builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -59,14 +59,6 @@ dependencies:
     - npm link spark-js-sdk--test-users
     - npm link spark-js-sdk--test-users:
         pwd: packages/test-helper-test-users
-    # lerna fork
-    - ls lerna > /dev/null 2> /dev/null || git clone git@github.com:ianwremmel/lerna.git:
-        pwd: ../
-    - git checkout de0f7f2:
-        pwd: ../lerna
-    - npm link:
-        pwd: ../lerna
-    - npm link lerna
   post:
     - npm run bootstrap
 

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "karma-mocha-reporter": "^2.0.4",
     "karma-safari-launcher": "^1.0.0",
     "karma-sauce-launcher": "^1.0.0",
-    "lerna": "git://github.com/ianwremmel/lerna.git#de0f7f2",
+    "lerna": "^2.0.0-beta.24",
     "load-grunt-tasks": "^3.5.0",
     "lodash": "^4.5.1",
     "mkdirp": "^0.5.1",

--- a/packages/example-phone/package.json
+++ b/packages/example-phone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciscospark/example-phone",
-  "version": "0.7.0-alpha.9ee819d2",
+  "version": "0.7.0-alpha.10dc6ffb",
   "description": "",
   "author": "Ian W. Remmel <iremmel@cisco.com>",
   "license": "(Apache-2.0)",
@@ -10,7 +10,7 @@
   },
   "repository": "https://github.com/ciscospark/spark-js-sdk/tree/master/packages/example-phone",
   "dependencies": {
-    "ciscospark": "^0.7.0-alpha.9ee819d2",
+    "ciscospark": "^0.7.0-alpha.10dc6ffb",
     "babel-runtime": "^6.3.19",
     "extract-text-webpack-plugin": "^1.0.1",
     "lodash": "^4.5.1",
@@ -29,11 +29,11 @@
     "redux-thunk": "^2.0.1"
   },
   "devDependencies": {
-    "@ciscospark/http-core": "^0.7.0-alpha.9ee819d2",
-    "@ciscospark/spark-core": "^0.7.0-alpha.9ee819d2",
-    "@ciscospark/test-helper-automation": "^0.7.0-alpha.9ee819d2",
-    "@ciscospark/test-helper-test-users": "^0.7.0-alpha.9ee819d2",
-    "@ciscospark/xunit-with-logs": "^0.7.0-alpha.9ee819d2",
+    "@ciscospark/http-core": "^0.7.0-alpha.10dc6ffb",
+    "@ciscospark/spark-core": "^0.7.0-alpha.10dc6ffb",
+    "@ciscospark/test-helper-automation": "^0.7.0-alpha.10dc6ffb",
+    "@ciscospark/test-helper-test-users": "^0.7.0-alpha.10dc6ffb",
+    "@ciscospark/xunit-with-logs": "^0.7.0-alpha.10dc6ffb",
     "babel-core": "^6.7.7",
     "babel-eslint": "^6.0.0-beta.5",
     "babel-plugin-lodash": "2.1.0",

--- a/tooling/circle-scripts/publish.sh
+++ b/tooling/circle-scripts/publish.sh
@@ -24,32 +24,36 @@ echo "Setting git credentials"
 git config --global user.email "spark-js-sdk@example.com"
 git config --global user.name "spark-js-sdk automation"
 
-echo "Creating temporary .npmrc"
-# Note the intentional single quotes to avoid string interpolation
-echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
+# Until https://github.com/lerna/lerna/issues/286 gets fixed, canary release are
+# more trouble than they're worth
+# echo "Creating temporary .npmrc"
+# # Note the intentional single quotes to avoid string interpolation
+# echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
+#
+# echo "Publishing new versions to npm"
+# set -x
+# # TODO deprecate previous versions?
+# # npm run lerna -- publish --repo-version=${NEXT_VERSION}
+# NPM_CONFIG_LOGLEVEL=info npm run lerna -- publish --skip-git --canary --yes
+# # TODO parse top commit message for something like !release:X.Y.Z to decide
+# # whether to do a canary release
+# NEW_VERSION="`cat lerna.json | grep version | awk '{print $2}'| sed -e 's/^"//'  -e 's/"$//'`-alpha.`git rev-parse --short HEAD`"
+# git add lerna.json package.json packages/*/package.json
+# git commit -m "Release ${NEW_VERSION}"
+# git tag -a -m "Release ${NEW_VERSION}" "${NEW_VERSION}"
+# git commit --allow-empty -m '[skip ci]'
+# git push origin HEAD:refs/heads/master
+# git push origin "${NEW_VERSION}"
 
-echo "Publishing new versions to npm"
-set -x
-# TODO deprecate previous versions?
-# npm run lerna -- publish --repo-version=${NEXT_VERSION}
-NPM_CONFIG_LOGLEVEL=info npm run lerna -- publish --skip-git --canary --yes
-# TODO parse top commit message for something like !release:X.Y.Z to decide
-# whether to do a canary release
-NEW_VERSION="`cat lerna.json | grep version | awk '{print $2}'| sed -e 's/^"//'  -e 's/"$//'`-alpha.`git rev-parse --short HEAD`"
-git add lerna.json package.json packages/*/package.json
-git commit -m "Release ${NEW_VERSION}"
-git tag -a -m "Release ${NEW_VERSION}" "${NEW_VERSION}"
-git commit --allow-empty -m '[skip ci]'
-git push origin HEAD:refs/heads/master
-git push origin "${NEW_VERSION}"
-
+# TODO only publish doc changes on release builds
 echo "Publishing new documentation"
 npm run grunt:circle -- publish-docs
 
-echo "Tricking npm website into updating the README"
-# Trick npmjs.com into updating the readme
-# See https://github.com/npm/newww/issues/389#issuecomment-188428605 and
-# https://github.com/lerna/lerna/issues/64 for details
-npm run lerna -- exec --scope ciscospark -- npm version --no-git-tag-version "${NEW_VERSION}-readmehack"
-npm run lerna -- exec --scope ciscospark -- npm publish --tag=readmehack
-npm run lerna -- exec --scope ciscospark -- npm unpublish ciscospark@"${NEW_VERSION}-readmehack"
+# Disabled until we turn releases back on
+# echo "Tricking npm website into updating the README"
+# # Trick npmjs.com into updating the readme
+# # See https://github.com/npm/newww/issues/389#issuecomment-188428605 and
+# # https://github.com/lerna/lerna/issues/64 for details
+# npm run lerna -- exec --scope ciscospark -- npm version --no-git-tag-version "${NEW_VERSION}-readmehack"
+# npm run lerna -- exec --scope ciscospark -- npm publish --tag=readmehack
+# npm run lerna -- exec --scope ciscospark -- npm unpublish ciscospark@"${NEW_VERSION}-readmehack"

--- a/tooling/jenkins-scripts/gate-jenkins.sh
+++ b/tooling/jenkins-scripts/gate-jenkins.sh
@@ -14,19 +14,6 @@ export XUNIT=true
 LOG_FILE="$(pwd)/test.log"
 rm -f "${LOG_FILE}"
 
-# Remove the lerna installed from npm so we can link the one from the fork
-rm -rf ./node_modules/lerna
-
-CWD=`pwd`
-
-cd /tmp
-ls lerna > /dev/null 2> /dev/null || git clone git@github.com:ianwremmel/lerna.git
-cd lerna
-git checkout de0f7f2
-npm link
-cd "${CWD}"
-npm link lerna
-
 # INSTALL
 echo "Installing modular SDK dependencies"
 npm run bootstrap


### PR DESCRIPTION
1. They're more trouble than they're worth due to https://github.com/lerna/lerna/pull/287
2. Using the forked lerna version may be impacting gating jobs