### PR TITLE
Add bufferState to socket url and register handler to messages before opening socket

### DIFF
--- a/src/client/mercury/mercury.js
+++ b/src/client/mercury/mercury.js
@@ -323,6 +323,7 @@ var Mercury = SparkBase.extend(
 
   _onmessage: function _onmessage(event) {
     event = event.data;
+
     if (event.headers) {
       this._moveHeadersToData(event);
     }

--- a/src/client/mercury/mercury.js
+++ b/src/client/mercury/mercury.js
@@ -166,9 +166,14 @@ var Mercury = SparkBase.extend(
   }),
 
   _attemptConnection: function _attemptConnection() {
+    var socket = this._getNewSocket();
+    socket.on('close', this._onclose.bind(this));
+    socket.on('message', this._onmessage.bind(this));
+    socket.on('sequence-mismatch', this.metrics.submitSkipSequenceMetric.bind(this.metrics));
+
     return this.spark.credentials.getAuthorization()
       .then(function connect(authorization) {
-        return Socket.open(this.spark.device.webSocketUrl, {
+        return socket.open(this.spark.device.webSocketUrl, {
           forceCloseDelay: this.config.forceCloseDelay,
           pingInterval: this.config.pingInterval,
           pongTimeout: this.config.pongTimeout,
@@ -177,11 +182,8 @@ var Mercury = SparkBase.extend(
           logger: this.logger
         });
       }.bind(this))
-      .then(function onconnect(socket) {
+      .then(function onconnect() {
         this.socket = socket;
-        this.socket.on('close', this._onclose.bind(this));
-        this.socket.on('message', this._onmessage.bind(this));
-        this.socket.on('sequence-mismatch', this.metrics.submitSkipSequenceMetric.bind(this.metrics));
         this.metrics.submitConnectMetric();
         this.trigger('online');
       }.bind(this))
@@ -202,6 +204,10 @@ var Mercury = SparkBase.extend(
 
         return Promise.reject(reason);
       }.bind(this));
+  },
+
+  _getNewSocket: function _getNewSocket() {
+    return new Socket();
   },
 
   /**

--- a/src/client/mercury/socket/socket-base.js
+++ b/src/client/mercury/socket/socket-base.js
@@ -10,7 +10,6 @@ var defaults = require('lodash.defaults');
 var EventEmitter = require('events').EventEmitter;
 var extendError = require('extend-error');
 var isObject = require('lodash.isobject');
-var resolveWith = require('../../../util/resolve-with');
 var shimPlaceholder = require('../../../lib/shim-placeholder');
 var util = require('util');
 var uuid = require('uuid');
@@ -132,7 +131,7 @@ assign(Socket.prototype, {
       }
 
       if (this._socket) {
-        return reject(new Error('Socket#open() can only be called once'));
+        return reject(new Error('socket#open() can only be called once'));
       }
 
       [
@@ -415,15 +414,7 @@ assign(Socket.prototype, {
 assign(Socket, {
   ConnectionError: ConnectionError,
 
-  AuthorizationError: AuthorizationError,
-
-  open: function open(url, options) {
-    return new Promise(function open(resolve) {
-      var socket = new Socket();
-      resolve(socket.open(url, options)
-        .then(resolveWith(socket)));
-    }.bind(this));
-  }
+  AuthorizationError: AuthorizationError
 });
 
 module.exports = Socket;

--- a/src/client/mercury/socket/socket-base.js
+++ b/src/client/mercury/socket/socket-base.js
@@ -169,6 +169,11 @@ assign(Socket.prototype, {
         url += ((url.indexOf('?') === -1) ? '?' : '&') + 'outboundWireFormat=text';
       }
 
+      /* istanbul ignore else */
+      if (url.indexOf('bufferStates=true') === -1) {
+        url += ((url.indexOf('?') === -1) ? '?' : '&') + 'bufferStates=true';
+      }
+
       this.logger.info('socket: connecting to websocket');
       this._socket = this._open(url);
 

--- a/src/client/mercury/socket/socket-base.js
+++ b/src/client/mercury/socket/socket-base.js
@@ -171,6 +171,9 @@ assign(Socket.prototype, {
 
       /* istanbul ignore else */
       if (url.indexOf('bufferStates=true') === -1) {
+        // It's unlikely bufferStates is the first parameter as
+        // outboundingWireFormat will be there first
+        /* istanbul ignore next */
         url += ((url.indexOf('?') === -1) ? '?' : '&') + 'bufferStates=true';
       }
 

--- a/src/client/mercury/socket/socket-base.js
+++ b/src/client/mercury/socket/socket-base.js
@@ -126,6 +126,7 @@ assign(Socket.prototype, {
     options = options || {};
 
     return new Promise(function open(resolve, reject) {
+      /* eslint complexity: [0] */
       if (!url) {
         return reject(new Error('`url` is required'));
       }

--- a/src/client/services/board/realtime/realtime.js
+++ b/src/client/services/board/realtime/realtime.js
@@ -98,9 +98,14 @@ var RealtimeService = Mercury.extend({
   },
 
   _attemptConnection: function _attemptConnection() {
+    var socket = this._getNewSocket();
+    socket.on('close', this._onclose.bind(this));
+    socket.on('message', this._onmessage.bind(this));
+    socket.on('sequence-mismatch', this.metrics.submitSkipSequenceMetric.bind(this.metrics));
+
     return this.spark.credentials.getAuthorization()
       .then(function connect(authorization) {
-        return Socket.open(this.spark.board.realtime.get('boardWebSocketUrl'), {
+        return socket.open(this.spark.board.realtime.get('boardWebSocketUrl'), {
           forceCloseDelay: this.config.forceCloseDelay,
           pingInterval: this.config.pingInterval,
           pongTimeout: this.config.pongTimeout,
@@ -109,11 +114,8 @@ var RealtimeService = Mercury.extend({
           logger: this.logger
         });
       }.bind(this))
-      .then(function onconnect(socket) {
+      .then(function onconnect() {
         this.socket = socket;
-        this.socket.on('close', this._onclose.bind(this));
-        this.socket.on('message', this._onmessage.bind(this));
-        this.socket.on('sequence-mismatch', this.metrics.submitSkipSequenceMetric.bind(this.metrics));
         this.metrics.submitConnectMetric();
         this.trigger('online');
       }.bind(this))

--- a/src/client/services/board/realtime/realtime.js
+++ b/src/client/services/board/realtime/realtime.js
@@ -102,7 +102,6 @@ var RealtimeService = Mercury.extend({
     socket.on('close', this._onclose.bind(this));
     socket.on('message', this._onmessage.bind(this));
     socket.on('sequence-mismatch', this.metrics.submitSkipSequenceMetric.bind(this.metrics));
-
     return this.spark.credentials.getAuthorization()
       .then(function connect(authorization) {
         return socket.open(this.spark.board.realtime.get('boardWebSocketUrl'), {

--- a/test/unit/lib/mock-socket.js
+++ b/test/unit/lib/mock-socket.js
@@ -17,7 +17,7 @@ function MockSocket() {
       value: sinon.spy()
     },
     open: {
-      value: sinon.spy()
+      value: sinon.stub()
     },
     send: {
       value: sinon.spy()

--- a/test/unit/spec/client/mercury/mercury.js
+++ b/test/unit/spec/client/mercury/mercury.js
@@ -581,12 +581,12 @@ describe('Client', function() {
         // Buffer state message is emitted after authorization
         spark.credentials.getAuthorization = function() {
           return new Promise(function(resolve) {
-            process.nextTick(function() {
+            resolve('Token');
+          })
+            .then(function() {
               assert.notCalled(onlineSpy);
               socket.emit('message', {data: bufferStateMessage});
             });
-            resolve('Token');
-          });
         };
 
         mercury.on('mercury.buffer_state', bufferSpy);

--- a/test/unit/spec/client/mercury/mercury.js
+++ b/test/unit/spec/client/mercury/mercury.js
@@ -36,11 +36,12 @@ describe('Client', function() {
       spark.logger = console;
 
       socket = new MockSocket();
-      socketOpenStub = sinon.stub(Socket, 'open');
+      socketOpenStub = socket.open;
       socketOpenStub.returns(Promise.resolve(socket));
 
       mercury = spark.mercury;
 
+      sinon.stub(mercury, '_getNewSocket').returns(socket);
       sinon.spy(mercury.metrics, 'submitConnectMetric');
       sinon.spy(mercury.metrics, 'submitConnectionFailureMetric');
       sinon.spy(mercury.metrics, 'submitDisconnectMetric');
@@ -80,12 +81,6 @@ describe('Client', function() {
         timestamp: Date.now(),
         trackingId: 'suffix_' + uuid.v4() + '_' + Date.now()
       };
-    });
-
-    afterEach(function() {
-      if (Socket.open.restore) {
-        Socket.open.restore();
-      }
     });
 
     describe('#listen()', function() {
@@ -140,7 +135,7 @@ describe('Client', function() {
           mercury.connect()
         ])
           .then(function() {
-            assert.calledOnce(Socket.open);
+            assert.calledOnce(socket.open);
           });
       });
 
@@ -149,10 +144,10 @@ describe('Client', function() {
           this.timeout(10000);
           mercury.config.maxRetries = 2;
           socketOpenStub.returns(Promise.reject(new Socket.ConnectionError()));
-          assert.notCalled(Socket.open);
+          assert.notCalled(socket.open);
           return assert.isRejected(mercury.connect())
             .then(function() {
-              assert.callCount(Socket.open, 3);
+              assert.callCount(socket.open, 3);
             });
         });
       });
@@ -164,20 +159,20 @@ describe('Client', function() {
           socketOpenStub.returns(Promise.reject(new Socket.ConnectionError()));
           // Note: onCall is zero-based
           socketOpenStub.onCall(2).returns(Promise.resolve(new MockSocket()));
-          assert.notCalled(Socket.open);
+          assert.notCalled(socket.open);
 
           var promise = mercury.connect();
           return delay(1000)
             .then(function() {
-              assert.calledOnce(Socket.open);
+              assert.calledOnce(socket.open);
               return delay(2000);
             })
             .then(function() {
-              assert.calledTwice(Socket.open);
+              assert.calledTwice(socket.open);
               return assert.isFulfilled(promise);
             })
             .then(function() {
-              assert.calledThrice(Socket.open);
+              assert.calledThrice(socket.open);
             });
         });
 
@@ -211,7 +206,7 @@ describe('Client', function() {
           this.timeout(5000);
           return delay(4000)
             .then(function() {
-              assert.calledOnce(Socket.open);
+              assert.calledOnce(socket.open);
             });
         });
       });
@@ -321,7 +316,7 @@ describe('Client', function() {
           mercury._reconnect()
         ])
           .then(function() {
-            assert.calledOnce(Socket.open);
+            assert.calledOnce(socket.open);
           });
       });
 
@@ -331,20 +326,20 @@ describe('Client', function() {
           socketOpenStub.returns(Promise.reject(new Socket.ConnectionError()));
           // Note: onCall is zero-based
           socketOpenStub.onCall(2).returns(Promise.resolve(new MockSocket()));
-          assert.notCalled(Socket.open);
+          assert.notCalled(socket.open);
 
           var promise = mercury._reconnect();
           return delay(1000)
             .then(function() {
-              assert.calledOnce(Socket.open);
+              assert.calledOnce(socket.open);
               return delay(2000);
             })
             .then(function() {
-              assert.calledTwice(Socket.open);
+              assert.calledTwice(socket.open);
               return assert.isFulfilled(promise);
             })
             .then(function() {
-              assert.calledThrice(Socket.open);
+              assert.calledThrice(socket.open);
             });
         });
 

--- a/test/unit/spec/client/mercury/mercury.js
+++ b/test/unit/spec/client/mercury/mercury.js
@@ -580,7 +580,7 @@ describe('Client', function() {
 
         // Buffer state message is emitted after authorization
         spark.credentials.getAuthorization = function() {
-          return new Promise(function(resolve, reject) {
+          return new Promise(function(resolve) {
             process.nextTick(function() {
               assert.notCalled(onlineSpy);
               socket.emit('message', {data: bufferStateMessage});

--- a/test/unit/spec/client/mercury/socket.js
+++ b/test/unit/spec/client/mercury/socket.js
@@ -219,16 +219,22 @@ describe('Client', function() {
           return assert.isRejected(socket.open('ws://example.com'), /Socket#open\(\) can only be called once/);
         });
 
-        it('ensures we always use text-mode WebSockets', function() {
+        it('ensures we always use text-mode WebSockets and get buffer states', function() {
           var s = new Socket();
           s.open('ws://example.com', mockoptions);
           assert.match(s.url, /outboundWireFormat=text/);
-          assert.equal(s.url, 'ws://example.com?outboundWireFormat=text');
+          assert.equal(s.url, 'ws://example.com?outboundWireFormat=text&bufferStates=true');
 
           s = new Socket();
           s.open('ws://example.com?queryparam=something', mockoptions);
           assert.match(s.url, /outboundWireFormat=text/);
-          assert.equal(s.url, 'ws://example.com?queryparam=something&outboundWireFormat=text');
+          assert.equal(s.url, 'ws://example.com?queryparam=something&outboundWireFormat=text&bufferStates=true');
+        });
+
+        it('does not duplicate url queries', function() {
+          var s = new Socket();
+          s.open('ws://example.com?outboundWireFormat=text&bufferStates=true', mockoptions);
+          assert.equal(s.url, 'ws://example.com?outboundWireFormat=text&bufferStates=true');
         });
 
         it('sets the underlying socket\'s binary type', function() {

--- a/test/unit/spec/client/mercury/socket.js
+++ b/test/unit/spec/client/mercury/socket.js
@@ -35,7 +35,8 @@ describe('Client', function() {
 
         sinon.spy(Socket.prototype, '_ping');
 
-        var promise = Socket.open('ws://example.com', mockoptions);
+        socket = new Socket();
+        var promise = socket.open('ws://example.com', mockoptions);
 
         try {
           _socket.readyState = 1;
@@ -57,7 +58,7 @@ describe('Client', function() {
         }
 
 
-        return promise.then(function(s) {
+        return promise.then(function() {
           _socket.emit('message', {
             data: JSON.stringify({
               id: JSON.parse(_socket.send.args[3][0]).id,
@@ -66,7 +67,6 @@ describe('Client', function() {
             })
           });
 
-          socket = s;
           _socket.readyState = 1;
         });
       });
@@ -82,83 +82,6 @@ describe('Client', function() {
         _socket = undefined;
       });
 
-      describe('.open()', function() {
-        it('requires a url parameter', function() {
-          return Promise.all([
-            assert.isRejected(Socket.open(), /`url` is required/)
-          ]);
-        });
-
-        it('requires a forceCloseDelay option', function() {
-          return assert.isRejected(Socket.open('ws://example.com'), /`options.forceCloseDelay` is required/);
-        });
-
-        it('requires a pingInterval option', function() {
-          return assert.isRejected(Socket.open('ws://example.com', {
-            forceCloseDelay: 100
-          }), /`options.pingInterval` is required/);
-        });
-
-        it('requires a pongTimeout option', function() {
-          return assert.isRejected(Socket.open('ws://example.com', {
-            forceCloseDelay: 100,
-            pingInterval: 100
-          }), /`options.pongTimeout` is required/);
-        });
-
-        it('requires a token option', function() {
-          return assert.isRejected(Socket.open('ws://example.com', {
-            forceCloseDelay: 100,
-            pingInterval: 100,
-            pongTimeout: 90
-          }), /`options.token` is required/);
-        });
-
-        it('requires a trackingI option', function() {
-          return assert.isRejected(Socket.open('ws://example.com'), {
-            forceCloseDelay: 100,
-            pingInterval: 100,
-            pongTimeout: 90,
-            token: 'mocktoken'
-          }, /`options.trackingId` is required/);
-        });
-
-        it('requires a logger option', function() {
-          return assert.isRejected(Socket.open('ws://example.com', {
-            forceCloseDelay: 100,
-            pingInterval: 100,
-            pongTimeout: 90,
-            token: 'mocktoken',
-            trackingId: 'mocktrackingid'
-          }), /`options.logger` is required/);
-        });
-
-        it('accepts a logLevelToken option', function() {
-          var promise = Socket.open('ws://example.com', {
-            forceCloseDelay: 100,
-            pingInterval: 100,
-            pongTimeout: 90,
-            logger: console,
-            token: 'mocktoken',
-            trackingId: 'mocktrackingid',
-            logLevelToken: 'mocklogleveltoken'
-          });
-
-          _socket.readyState = 1;
-          _socket.emit('open');
-
-          _socket.emit('message', {
-            data: JSON.stringify({
-              id: JSON.parse(_socket.send.args[1][0]).id,
-              type: 'pong'
-            })
-          });
-
-          return promise.then(function(s) {
-            assert.equal(s.logLevelToken, 'mocklogleveltoken');
-          });
-        });
-      });
 
       describe('#binaryType', function() {
         it('proxies to the underlying socket', function() {
@@ -214,9 +137,86 @@ describe('Client', function() {
           return assert.isRejected(s.open(), /`url` is required/);
         });
 
+        it('requires a forceCloseDelay option', function() {
+          var s = new Socket();
+          return assert.isRejected(s.open('ws://example.com'), /`options.forceCloseDelay` is required/);
+        });
+
+        it('requires a pingInterval option', function() {
+          var s = new Socket();
+          return assert.isRejected(s.open('ws://example.com', {
+            forceCloseDelay: 100
+          }), /`options.pingInterval` is required/);
+        });
+
+        it('requires a pongTimeout option', function() {
+          var s = new Socket();
+          return assert.isRejected(s.open('ws://example.com', {
+            forceCloseDelay: 100,
+            pingInterval: 100
+          }), /`options.pongTimeout` is required/);
+        });
+
+        it('requires a token option', function() {
+          var s = new Socket();
+          return assert.isRejected(s.open('ws://example.com', {
+            forceCloseDelay: 100,
+            pingInterval: 100,
+            pongTimeout: 90
+          }), /`options.token` is required/);
+        });
+
+        it('requires a trackingI option', function() {
+          var s = new Socket();
+          return assert.isRejected(s.open('ws://example.com'), {
+            forceCloseDelay: 100,
+            pingInterval: 100,
+            pongTimeout: 90,
+            token: 'mocktoken'
+          }, /`options.trackingId` is required/);
+        });
+
+        it('requires a logger option', function() {
+          var s = new Socket();
+          return assert.isRejected(s.open('ws://example.com', {
+            forceCloseDelay: 100,
+            pingInterval: 100,
+            pongTimeout: 90,
+            token: 'mocktoken',
+            trackingId: 'mocktrackingid'
+          }), /`options.logger` is required/);
+        });
+
+        it('accepts a logLevelToken option', function() {
+          var s = new Socket();
+          var promise = s.open('ws://example.com', {
+            forceCloseDelay: 100,
+            pingInterval: 100,
+            pongTimeout: 90,
+            logger: console,
+            token: 'mocktoken',
+            trackingId: 'mocktrackingid',
+            logLevelToken: 'mocklogleveltoken'
+          });
+
+          _socket.readyState = 1;
+          _socket.emit('open');
+
+          _socket.emit('message', {
+            data: JSON.stringify({
+              id: JSON.parse(_socket.send.args[1][0]).id,
+              type: 'pong'
+            })
+          });
+
+          return promise.then(function() {
+            assert.equal(s.logLevelToken, 'mocklogleveltoken');
+          });
+        });
+
         it('cannot be called more than once', function() {
           assert.isDefined(socket._socket);
-          return assert.isRejected(socket.open('ws://example.com'), /Socket#open\(\) can only be called once/);
+          return assert.isRejected(socket.open('ws://example.com'), /socket#open\(\) can only be called once/);
         });
 
         it('ensures we always use text-mode WebSockets and get buffer states', function() {
@@ -379,7 +379,8 @@ describe('Client', function() {
         });
 
         it('signals close if no close frame received within a specified window', function() {
-          var promise = Socket.open('ws://example.com', mockoptions);
+          var s = new Socket();
+          var promise = s.open('ws://example.com', mockoptions);
           _socket.readyState = 1;
           _socket.emit('open');
           _socket.emit('message', {
@@ -389,7 +390,7 @@ describe('Client', function() {
             })
           });
           return promise
-            .then(function(s) {
+            .then(function() {
               var spy = sinon.spy();
               s.on('close', spy);
               _socket.close = function() {return new Promise(function() {});};

--- a/test/unit/spec/services/board/realtime.js
+++ b/test/unit/spec/services/board/realtime.js
@@ -150,7 +150,7 @@ describe('Services', function() {
 
           // Buffer state message is emitted after authorization
           spark.credentials.getAuthorization = function() {
-            return new Promise(function(resolve, reject) {
+            return new Promise(function(resolve) {
               process.nextTick(function() {
                 assert.notCalled(onlineSpy);
                 spark.board.realtime.socket.emit('message', {data: bufferStateMessage});

--- a/test/unit/spec/services/board/realtime.js
+++ b/test/unit/spec/services/board/realtime.js
@@ -151,12 +151,12 @@ describe('Services', function() {
           // Buffer state message is emitted after authorization
           spark.credentials.getAuthorization = function() {
             return new Promise(function(resolve) {
-              process.nextTick(function() {
+              resolve('Token');
+            })
+              .then(function() {
                 assert.notCalled(onlineSpy);
                 spark.board.realtime.socket.emit('message', {data: bufferStateMessage});
               });
-              resolve('Token');
-            });
           };
 
           spark.board.realtime.on('mercury.buffer_state', bufferSpy);

--- a/test/unit/spec/services/board/realtime.js
+++ b/test/unit/spec/services/board/realtime.js
@@ -35,18 +35,16 @@ describe('Services', function() {
             encryptText: sinon.stub().returns(Promise.resolve(encryptedData))
           }
         });
+
         spark.board.realtime.boardBindings = ['bindings'];
         spark.board.realtime.socket = new MockSocket();
+        spark.board.realtime._getNewSocket = sinon.stub().returns(spark.board.realtime.socket);
 
-        socketOpenStub = sinon.stub(Socket, 'open');
+        socketOpenStub = spark.board.realtime.socket.open;
         socketOpenStub.returns(Promise.resolve(spark.board.realtime.socket));
 
         sinon.spy(spark.board.realtime.metrics, 'submitConnectionFailureMetric');
 
-      });
-
-      after(function() {
-        Socket.open.restore();
       });
 
       describe('#publish()', function testSetBoardWebSocketUrl() {


### PR DESCRIPTION
- Add the query bufferState to url so that we get buffer state everytime
- Register handler to socket messages before opening socket so what we won't miss the buffer state message
Code changes only in legacy as current plugin-mercury already has it