### PR TITLE
fix(encryption): downgrade node-jose to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "lodash.values": "^3.0.0",
     "lodash.where": "^3.1.0",
     "mmmagic": "~0.3.14",
-    "node-jose": "~0.9.0",
+    "node-jose": "0.8.0",
     "node-kms": "~0.3.1",
     "node-scr": "~0.2.1",
     "redux-localstorage": "^1.0.0-rc4",


### PR DESCRIPTION
Seem that 0.8.1 introduced some breaking changes.

To break decryption:

1. locally deploy web-client with local sdk
2. Verify that decryption is working by opening the web client.
3. Upgrade to version 0.8.1 of node-jose: `npm i node-jose@0.8.1`
4. Restart web client server (optional) and open web-client.  No comments or files should be viewable.