### PR TITLE
Downgrade node jose

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "lodash.values": "^3.0.0",
     "lodash.where": "^3.1.0",
     "mmmagic": "~0.3.14",
-    "node-jose": "0.8.0",
+    "node-jose": "0.4.0",
     "node-kms": "~0.3.1",
     "node-scr": "~0.2.1",
     "redux-localstorage": "^1.0.0-rc4",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "lodash.values": "^3.0.0",
     "lodash.where": "^3.1.0",
     "mmmagic": "~0.3.14",
-    "node-jose": "~0.9.0",
+    "node-jose": "0.8.0",
     "node-kms": "~0.3.1",
     "node-scr": "~0.2.1",
     "redux-localstorage": "^1.0.0-rc4",

--- a/src/client/services/team/team.js
+++ b/src/client/services/team/team.js
@@ -310,7 +310,6 @@ var TeamService = SparkBase.extend(
    * Move an existing group conversation into a team.
    * @param {TeamObject} team
    * @param {ConversationObject} conversation
-   * @param {Object} options
    * @returns {Promise} Resolves with the add activity
    */
   addConversation: function addConversation(team, conversation) {


### PR DESCRIPTION
We should revert node-jose because:

1. Nothing would decrypt using version 0.9.1. (version 0.8.1  includes the breaking change)
2. Newly created rooms were unavailable for 0.8.0. (version 0.7.1  includes the breaking change)
3. Automated tests did not catch either of these issues, so we should revert to last good config.
