### PR TITLE
chore: package generator version to 0.7.0-alpha

### DIFF
--- a/packages/generator-ciscospark/generators/package/templates/_package.json
+++ b/packages/generator-ciscospark/generators/package/templates/_package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciscospark/<%= packagename %>",
-  "version": "0.6.0",
+  "version": "0.7.0-alpha",
   "description": "<%= description %>",
   "main": "dist/index.js",
   "devMain": "src/index.js",
@@ -8,17 +8,17 @@
   "license": "(Apache-2.0)",
   "repository": "https://github.com/ciscospark/spark-js-sdk/tree/master/packages/<%= packagename %>",
   "dependencies": {
-    "@ciscospark/common": "^0.6.0",
-    "@ciscospark/spark-core": "^0.6.0",
+    "@ciscospark/common": "^0.7.0-alpha",
+    "@ciscospark/spark-core": "^0.7.0-alpha",
     "babel-runtime": "^6.3.19",
     "lodash": "^4.5.1"
   },
   "devDependencies": {
-    "@ciscospark/test-helper-chai": "^0.6.0",
-    "@ciscospark/test-helper-mocha": "^0.6.0",
-    "@ciscospark/test-helper-sinon": "^0.6.0",
-    "@ciscospark/test-helper-test-users": "^0.6.0",
-    "@ciscospark/xunit-with-logs": "^0.6.0",
+    "@ciscospark/test-helper-chai": "^0.7.0-alpha",
+    "@ciscospark/test-helper-mocha": "^0.7.0-alpha",
+    "@ciscospark/test-helper-sinon": "^0.7.0-alpha",
+    "@ciscospark/test-helper-test-users": "^0.7.0-alpha",
+    "@ciscospark/xunit-with-logs": "^0.7.0-alpha",
     "babel-eslint": "^6.0.0-beta.5",
     "babel-plugin-lodash": "2.1.0",
     "babel-polyfill": "^6.3.14",


### PR DESCRIPTION
The package generator fails on `npm install` due to version 0.6.0 of many packages not being available. This resolves it.