### PR TITLE
fix(spark-core): fix excess logs caused by missing cache

### DIFF
--- a/packages/spark-core/src/plugins/credentials/credentials/node.js
+++ b/packages/spark-core/src/plugins/credentials/credentials/node.js
@@ -4,27 +4,13 @@
  * @private
  */
 
-import {oneFlight} from '@ciscospark/common';
 import SparkPlugin from '../../../lib/spark-plugin';
 import common from './common';
-import {persist, waitForValue} from '../../../lib/storage';
 
 /**
  * @class
  * @extends CredentialsBase
  */
-const Credentials = SparkPlugin.extend(Object.assign({}, common, {
-  @oneFlight
-  @waitForValue(`authorization`)
-  authorize(...args) {
-    return Reflect.apply(common.authorize, this, args);
-  },
-
-  @persist(`authorization`)
-  @persist(`clientAuthorization`)
-  initialize(...args) {
-    return Reflect.apply(SparkPlugin.prototype.initialize, this, args);
-  }
-}));
+const Credentials = SparkPlugin.extend(common);
 
 export default Credentials;


### PR DESCRIPTION
Also fix incorrect loadding of "@" data and prevent duplicate decoration
caused by browser/node split implementations

Fixes #119