### PR TITLE
feat(board): added API for listing boards by converstionId

### DIFF
--- a/src/client/services/board/board.js
+++ b/src/client/services/board/board.js
@@ -7,8 +7,10 @@
 
 /* eslint-env browser */
 
+var isarray = require('lodash.isarray');
 var Persistence = require('./persistence');
 var Realtime = require('./realtime');
+var reduce = require('lodash.reduce');
 var SparkBase = require('../../../lib/spark-base');
 var defaults = require('lodash.defaults');
 
@@ -158,6 +160,31 @@ var BoardService = SparkBase.extend({
           encryptionKeyUrl: encryptionKeyUrl
         };
       });
+  },
+
+  /**
+   * Separate a single link header string into an actionable object
+   * @param {string} linkHeaders
+   * @private
+   * @returns {Object}
+   */
+  parseLinkHeaders: function parseLinkHeaders(linkHeaders) {
+    if (!linkHeaders) {
+      return {};
+    }
+
+    linkHeaders = isarray(linkHeaders) ? linkHeaders : [linkHeaders];
+    return reduce(linkHeaders, function reduceLinkHeaders(links, linkHeader) {
+      linkHeader = linkHeader.split(';');
+      var link = linkHeader[0]
+        .replace('<', '')
+        .replace('>', '');
+      var rel = linkHeader[1]
+        .split('=')[1]
+        .replace(/"/g, '');
+      links[rel] = link;
+      return links;
+    }, {});
   },
 
   processActivityEvent: function processActivityEvent(message) {

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+var assign = require('lodash.assign');
 var SparkBase = require('../../../../lib/spark-base');
 var chunk = require('lodash.chunk');
 var pick = require('lodash.pick');
@@ -178,6 +179,35 @@ var PersistenceService = SparkBase.extend({
       .then(function resolveWithBody(res) {
         return res.body;
       });
+  },
+
+  /**
+   * Gets Channels
+   * @memberof Board.PersistenceService
+   * @param {Object} options
+   * @param {number} options.limit Max number of activities to return
+   * @return {Promise} Resolves with an array of Channel items
+   */
+  getChannels: function getChannels(options) {
+    options = options || {};
+
+    if (!options.conversationId) {
+      return Promise.reject(new Error('`conversationId` is required'));
+    }
+
+    var params = {
+      api: 'board',
+      resource: '/channels',
+      qs: {}
+    };
+    assign(params.qs, pick(options, 'channelsLimit', 'conversationId'));
+
+    return this.request(params)
+      .then(function resolveWithBody(res) {
+        var responseObject = res.body;
+        responseObject.links = this.spark.board.parseLinkHeaders(res.headers.link);
+        return responseObject;
+      }.bind(this));
   },
 
   /**

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -457,15 +457,16 @@ describe('Services', function() {
           return ensureBoard();
         });
 
-        it('lists board after creating it', function() {
+        it('retrieves a newly created board for a specified conversation within a single page', function() {
           return party.spock.spark.board.persistence.getChannels({conversationId: conversation.id})
-            .then(function(channels) {
-              var channelFound = find(channels.items, {channelId: board.channelId});
+            .then(function(getChannelsResp) {
+              var channelFound = find(getChannelsResp.items, {channelId: board.channelId});
               assert.isDefined(channelFound);
+              assert.notProperty(getChannelsResp.links, 'next');
             });
         });
 
-        it('presents pagination link if more results than `limit`', function() {
+        it('retrieves all boards for a specified conversation across multiple pages', function() {
           var pageLimit = 10;
           var conversation;
 
@@ -505,6 +506,7 @@ describe('Services', function() {
             })
             .then(function(getChannelsResp) {
               assert.lengthOf(getChannelsResp.items, 1);
+              assert.notProperty(getChannelsResp, 'links');
             });
         });
       });

--- a/test/unit/spec/services/board/board.js
+++ b/test/unit/spec/services/board/board.js
@@ -271,5 +271,31 @@ describe('Services', function() {
           });
       });
     });
+
+    describe('#parseLinkHeaders', function() {
+
+      it('parses link header as undefined', function() {
+        var linkHeader = undefined;
+        assert.deepEqual(spark.board.parseLinkHeaders(linkHeader), {});
+      });
+
+      it('parses link header as string', function() {
+        var linkHeader = '<https://www.cisco.com>; rel=cisco';
+        assert.deepEqual(spark.board.parseLinkHeaders(linkHeader), {
+          cisco: 'https://www.cisco.com'
+        });
+      });
+
+      it('parses link header as array of headers', function() {
+        var linkHeader = [
+          '<https://www.ciscospark.com>; rel=ciscospark',
+          '<https://www.cisco.com>; rel=cisco'
+        ];
+        assert.deepEqual(spark.board.parseLinkHeaders(linkHeader), {
+          ciscospark: 'https://www.ciscospark.com',
+          cisco: 'https://www.cisco.com'
+        });
+      });
+    });
   });
 });

--- a/test/unit/spec/services/board/board.js
+++ b/test/unit/spec/services/board/board.js
@@ -279,7 +279,7 @@ describe('Services', function() {
         assert.deepEqual(spark.board.parseLinkHeaders(linkHeader), {});
       });
 
-      it('returns object contiaining one link if only one link header passed as a string', function() {
+      it('returns object containing one link if only one link header passed as a string', function() {
         var linkHeader = '<https://www.cisco.com>; rel=cisco';
         assert.deepEqual(spark.board.parseLinkHeaders(linkHeader), {
           cisco: 'https://www.cisco.com'

--- a/test/unit/spec/services/board/board.js
+++ b/test/unit/spec/services/board/board.js
@@ -274,19 +274,19 @@ describe('Services', function() {
 
     describe('#parseLinkHeaders', function() {
 
-      it('parses link header as undefined', function() {
+      it('returns empty object if there are not any link headers', function() {
         var linkHeader = undefined;
         assert.deepEqual(spark.board.parseLinkHeaders(linkHeader), {});
       });
 
-      it('parses link header as string', function() {
+      it('returns object contiaining one link if only one link header passed as a string', function() {
         var linkHeader = '<https://www.cisco.com>; rel=cisco';
         assert.deepEqual(spark.board.parseLinkHeaders(linkHeader), {
           cisco: 'https://www.cisco.com'
         });
       });
 
-      it('parses link header as array of headers', function() {
+      it('returns object containing multiple links when multiple headers passed as an array', function() {
         var linkHeader = [
           '<https://www.ciscospark.com>; rel=ciscospark',
           '<https://www.cisco.com>; rel=cisco'

--- a/test/unit/spec/services/board/persistence.js
+++ b/test/unit/spec/services/board/persistence.js
@@ -130,7 +130,7 @@ describe('Services', function() {
           });
         });
 
-        it('requires a conversationId', function() {
+        it('requires a conversationId as an option', function() {
           return Promise.all([
             assert.isRejected(spark.board.persistence.getChannels(), '`conversationId` is required')
           ]);

--- a/test/unit/spec/services/board/persistence.js
+++ b/test/unit/spec/services/board/persistence.js
@@ -10,11 +10,13 @@ if (typeof Promise === 'undefined') {
 }
 
 var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
 var Board = require('../../../../../src/client/services/board');
 var MockSpark = require('../../../lib/mock-spark');
 var sinon = require('sinon');
 var assert = chai.assert;
 
+chai.use(chaiAsPromised);
 sinon.assert.expose(chai.assert, {prefix: ''});
 
 describe('Services', function() {
@@ -118,6 +120,31 @@ describe('Services', function() {
           }));
         });
 
+      });
+
+      describe('#getChannels()', function() {
+
+        before(function() {
+          spark.board.persistence.getChannels({
+            conversationId: 'fakeConversationId'
+          });
+        });
+
+        it('requires a conversationId', function() {
+          return Promise.all([
+            assert.isRejected(spark.board.persistence.getChannels(), '`conversationId` is required')
+          ]);
+        });
+
+        it('requests GET to channels service', function() {
+          assert.calledWith(spark.request, sinon.match({
+            api: 'board',
+            resource: '/channels',
+            qs: {
+              conversationId: 'fakeConversationId'
+            }
+          }));
+        });
       });
 
       describe('#addContent()', function() {


### PR DESCRIPTION
Added the api for board listing, which is fairly straight forward.  The only controversial element of this PR is the fact that I "ported" the parseLinkHeaders function to es5 and added to the board object.  In parallel, the board service is being ported to the modular SDK, which will obviously have this function omitted in favor of using the the Page object.