### PR TITLE
feat(plugin-board): add upload snapshot for board 

### DIFF
--- a/packages/plugin-board/src/board.js
+++ b/packages/plugin-board/src/board.js
@@ -87,6 +87,7 @@ const Board = SparkPlugin.extend({
             fileSize: image.size
           }
         };
+
         return this.spark.request({
           method: `PATCH`,
           api: `board`,

--- a/packages/plugin-board/src/board.js
+++ b/packages/plugin-board/src/board.js
@@ -57,14 +57,14 @@ const Board = SparkPlugin.extend({
   },
 
   /**
-   * Adds a snapshot image of the board
+   * Set a snapshot image for a board
    *
    * @param {Conversation} conversation - the current conversation that the board belongs
    * @param {Board~Channel} channel
    * @param {File} image
    * @returns {Promise<Board~Channel>}
    */
-  addSnapshotImage(conversation, channel, image) {
+  setSnapshotImage(conversation, channel, image) {
     let imageScr;
     return this.spark.board._uploadImage(conversation, image)
       .then((scr) => {

--- a/packages/plugin-board/src/index.js
+++ b/packages/plugin-board/src/index.js
@@ -34,11 +34,13 @@ registerPlugin(`board`, Board, {
           }
 
           // we must have a encryptionKeyUrl
+          /* istanbul ignore if */
           if (!get(options, `body.items[0].encryptionKeyUrl`)) {
             return Promise.resolve(false);
           }
 
           // we must have a payload
+          /* istanbul ignore if */
           if (!get(options, `body.items[0].payload`)) {
             return Promise.resolve(false);
           }

--- a/packages/plugin-board/test/integration/spec/board.js
+++ b/packages/plugin-board/test/integration/spec/board.js
@@ -84,6 +84,25 @@ describe(`plugin-board`, () => {
       });
     });
 
+    describe(`#addSnapshotImage()`, () => {
+
+      after(() => participants[0].spark.board.deleteAllContent(board));
+
+      it(`uploads image to spark files and adds to channel`, () => {
+        let imageRes;
+        return participants[0].spark.board.addSnapshotImage(conversation, board, fixture)
+          .then((res) => {
+            imageRes = res.image;
+            assert.isDefined(res.image, `image field is included`);
+            assert.equal(res.image.encryptionKeyUrl, conversation.encryptionKeyUrl);
+            assert.isAbove(res.image.scr.length, 0, `scr string exists`);
+            return participants[1].spark.board.getChannel(board);
+          })
+          .then((res) => {
+            assert.deepEqual(imageRes, res.image);
+          });
+      });
+    });
 
     describe(`#ping()`, () => {
 

--- a/packages/plugin-board/test/integration/spec/board.js
+++ b/packages/plugin-board/test/integration/spec/board.js
@@ -84,13 +84,13 @@ describe(`plugin-board`, () => {
       });
     });
 
-    describe(`#addSnapshotImage()`, () => {
+    describe(`#setSnapshotImage()`, () => {
 
       after(() => participants[0].spark.board.deleteAllContent(board));
 
       it(`uploads image to spark files and adds to channel`, () => {
         let imageRes;
-        return participants[0].spark.board.addSnapshotImage(conversation, board, fixture)
+        return participants[0].spark.board.setSnapshotImage(conversation, board, fixture)
           .then((res) => {
             imageRes = res.image;
             assert.isDefined(res.image, `image field is included`);

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -92,10 +92,7 @@ var PersistenceService = SparkBase.extend({
         imageScr.encryptedScr = encryptedScr;
         return encryptedScr;
       }.bind(this))
-      .then(function getChannelInfo() {
-        return this.spark.board.persistence.getChannel(channel);
-      }.bind(this))
-      .then(function addSnapshotToChannel(channelInfo) {
+      .then(function addSnapshotToChannel() {
         var imageBody = {
           image: {
             url: imageScr.loc,
@@ -108,12 +105,11 @@ var PersistenceService = SparkBase.extend({
             updateInterval: 360000
           }
         };
-        var channelBody = assign({}, channelInfo, imageBody);
         return this.spark.request({
-          method: 'PUT',
+          method: 'PATCH',
           api: 'board',
           resource: '/channels/' + channel.channelId,
-          body: channelBody
+          body: imageBody
         });
       }.bind(this))
       .then(function returnSnapshotRes(res) {

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -68,14 +68,14 @@ var PersistenceService = SparkBase.extend({
 
 
   /**
-   * Adds a snapshot image of the board
+   * Set a snapshot image for a board
    *
    * @param {Conversation} conversation - the current conversation that the board belongs
    * @param {Board~Channel} channel
    * @param {File} image
    * @returns {Promise<Board~Channel>}
    */
-  addSnapshotImage: function addSnapshotImage(conversation, channel, image) {
+  setSnapshotImage: function setSnapshotImage(conversation, channel, image) {
     var imageScr;
     return this.spark.board._uploadImage(conversation, image)
       .then(function encryptScr(scr) {
@@ -86,7 +86,7 @@ var PersistenceService = SparkBase.extend({
         imageScr.encryptedScr = encryptedScr;
         return encryptedScr;
       }.bind(this))
-      .then(function addSnapshotToChannel() {
+      .then(function setSnapshotInChannel() {
         var imageBody = {
           image: {
             url: imageScr.loc,

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -347,6 +347,32 @@ describe('Services', function() {
         });
       });
 
+      describe('#addSnapshotImage()', function() {
+        var fixture = {
+          png: 'sample-image-small-one.png'
+        };
+
+        before(function() {
+          return fixtures.fetchFixtures(fixture)
+            .then(function() {
+              return ensureBoard();
+            });
+        });
+
+        after(function() {
+          return party.mccoy.spark.board.persistence.deleteAllContent(board);
+        });
+
+        it('uploads image to spark files', function() {
+          return party.mccoy.spark.board.persistence.addSnapshotImage(conversation, board, fixture.png)
+            .then(function(res) {
+              assert.isDefined(res.image, 'image field is included');
+              assert.equal(res.image.encryptionKeyUrl, conversation.encryptionKeyUrl);
+              assert.isAbove(res.image.scr.length, 0, 'scr string exists');
+            });
+        });
+      });
+
       describe('#getContents()', function() {
 
         before(function() {

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -363,12 +363,18 @@ describe('Services', function() {
           return party.mccoy.spark.board.persistence.deleteAllContent(board);
         });
 
-        it('uploads image to spark files', function() {
+        it('uploads image to spark files and then add image to channel', function() {
+          var imageRes;
           return party.mccoy.spark.board.persistence.addSnapshotImage(conversation, board, fixture.png)
             .then(function(res) {
+              imageRes = res.image;
               assert.isDefined(res.image, 'image field is included');
               assert.equal(res.image.encryptionKeyUrl, conversation.encryptionKeyUrl);
               assert.isAbove(res.image.scr.length, 0, 'scr string exists');
+              return party.spock.spark.board.persistence.getChannel(board);
+            })
+            .then(function(res) {
+              assert.deepEqual(res.image, imageRes);
             });
         });
       });

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -347,7 +347,7 @@ describe('Services', function() {
         });
       });
 
-      describe('#addSnapshotImage()', function() {
+      describe('#setSnapshotImage()', function() {
         var fixture = {
           png: 'sample-image-small-one.png'
         };
@@ -365,7 +365,7 @@ describe('Services', function() {
 
         it('uploads image to spark files and then add image to channel', function() {
           var imageRes;
-          return party.mccoy.spark.board.persistence.addSnapshotImage(conversation, board, fixture.png)
+          return party.mccoy.spark.board.persistence.setSnapshotImage(conversation, board, fixture.png)
             .then(function(res) {
               imageRes = res.image;
               assert.isDefined(res.image, 'image field is included');

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -409,7 +409,7 @@ describe('Services', function() {
           var tonsOfContents = generateTonsOfContents(400);
           return party.mccoy.spark.board.persistence.addContent(conversation, board, tonsOfContents)
             .then(function() {
-              return party.mccoy.spark.board.persistence.getAllContent(board);
+              return party.mccoy.spark.board.persistence.getAllContent(board, {contentsLimit: 150});
             })
             .then(function(res) {
               assert.equal(res.length, tonsOfContents.length);


### PR DESCRIPTION
To add a snapshot for a white board, we upload the snapshot image to spark files then attach metadata to a board.
Resolves #273