### PR TITLE
refactor(widget-chat): remove shouldComponentUpdate from redux comps

### DIFF
--- a/packages/widget-chat/src/containers/chat-widget/index.js
+++ b/packages/widget-chat/src/containers/chat-widget/index.js
@@ -41,7 +41,8 @@ import ConfirmationModal from '../../components/confirmation-modal';
 /**
  * ChatWidget Component
  */
-export class ChatWidget extends Component {
+// eslint-disable-reason Redux connect gives us shouldComponentUpdate smarts
+export class ChatWidget extends Component { // eslint-disable-line react/require-optimization
   constructor(props) {
     super(props);
     this.getActivityList = this.getActivityList.bind(this);
@@ -83,24 +84,6 @@ export class ChatWidget extends Component {
     }
   }
 
-  /* eslint-disable complexity */
-  /* eslint-disable-reason: Lots of checks for better efficiency, will be broken up later */
-  shouldComponentUpdate(nextProps) {
-    const props = this.props;
-
-    /* eslint-disable operator-linebreak */
-    /* eslint-disable-reason: Giant list of comparisons very difficult to read and diff */
-    return nextProps.conversation.activities !== props.conversation.activities
-      || nextProps.conversation.isLoadingHistoryUp !== props.conversation.isLoadingHistoryUp
-      || nextProps.flags !== props.flags
-      || nextProps.indicators !== props.indicators
-      || nextProps.share !== props.share
-      || nextProps.sparkState.connected !== props.sparkState.connected
-      || nextProps.user !== props.user
-      || nextProps.widget !== props.widget;
-    /* eslint-enable operator-linebreak */
-  }
-  /* eslint-enable complexity */
 
   componentWillUpdate(nextProps) {
     const props = this.props;

--- a/packages/widget-chat/src/containers/message-composer/index.js
+++ b/packages/widget-chat/src/containers/message-composer/index.js
@@ -9,16 +9,12 @@ import AddFileButton from '../../components/add-file-button';
 
 import styles from './styles.css';
 
-export class MessageComposer extends Component {
+// eslint-disable-reason Redux connect gives us shouldComponentUpdate smarts
+export class MessageComposer extends Component { // eslint-disable-line react/require-optimization
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
-  }
-
-  shouldComponentUpdate(nextProps) {
-    const props = this.props;
-    return props.value !== nextProps.value;
   }
 
   handleChange(e) {


### PR DESCRIPTION
Redux automatically optimizes the `shouldComponentUpdate` method via `connect`. Since we aren't doing anything special besides checking state props, let's remove them.