### PR TITLE
feat(board): Board ACL Switch

### DIFF
--- a/packages/plugin-board/package.json
+++ b/packages/plugin-board/package.json
@@ -9,9 +9,10 @@
   "repository": "https://github.com/ciscospark/spark-js-sdk/tree/master/packages/plugin-board",
   "dependencies": {
     "@ciscospark/common": "^0.7.32",
-    "@ciscospark/plugin-mercury": "^0.7.32",
     "@ciscospark/plugin-conversation": "^0.7.32",
     "@ciscospark/plugin-encryption": "^0.7.32",
+    "@ciscospark/plugin-feature": "^0.7.32",
+    "@ciscospark/plugin-mercury": "^0.7.32",
     "@ciscospark/spark-core": "^0.7.32",
     "babel-runtime": "^6.3.19",
     "es6-promise-series": "^0.2.2",

--- a/packages/plugin-board/src/index.js
+++ b/packages/plugin-board/src/index.js
@@ -7,6 +7,7 @@
 import '@ciscospark/plugin-mercury';
 import '@ciscospark/plugin-encryption';
 import '@ciscospark/plugin-conversation';
+import '@ciscospark/plugin-feature';
 
 import {registerPlugin} from '@ciscospark/spark-core';
 import Board from './board';

--- a/packages/plugin-board/src/index.js
+++ b/packages/plugin-board/src/index.js
@@ -55,7 +55,7 @@ registerPlugin(`board`, Board, {
         direction: `outbound`,
 
         test(ctx, options) {
-          if (get(options, `service`) === `board` && has(options, `body.aclUrlLink`)) {
+          if (ctx.spark.device.isSpecificService(`board`, options.uri) && has(options, `body.aclUrlLink`)) {
             return Promise.resolve(true);
           }
           return Promise.resolve(false);

--- a/packages/plugin-board/src/realtime.js
+++ b/packages/plugin-board/src/realtime.js
@@ -29,20 +29,20 @@ const RealtimeService = Mercury.extend({
   /**
     * Sends the message via the socket. Assumes that the message is already properly formatted
     * @memberof Board.RealtimeService
-    * @param {Conversation} conversation
+    * @param {Board~Channel} channel
     * @param {string} message   Contains the un-encrypted message to send.
     * @returns {Promise<Board~Content>}
     */
-  publish(conversation, message) {
+  publish(channel, message) {
     let encryptionPromise;
     let contentType = `STRING`;
 
     if (message.payload.scr) {
       contentType = `FILE`;
-      encryptionPromise = this.spark.board.encryptSingleFileContent(conversation.defaultActivityEncryptionKeyUrl, message.payload);
+      encryptionPromise = this.spark.board.encryptSingleFileContent(channel.defaultEncryptionKeyUrl, message.payload);
     }
     else {
-      encryptionPromise = this.spark.board.encryptSingleContent(conversation.defaultActivityEncryptionKeyUrl, message.payload);
+      encryptionPromise = this.spark.board.encryptSingleContent(channel.defaultEncryptionKeyUrl, message.payload);
     }
 
     return encryptionPromise

--- a/packages/plugin-board/test/integration/spec/board.js
+++ b/packages/plugin-board/test/integration/spec/board.js
@@ -115,9 +115,9 @@ describe(`plugin-board`, () => {
           .then((res) => {
             assert.deepEqual(imageRes, res.image);
             // ensure others can download the image
-            return participants[1].spark.encryption.decryptScr(board.defaultEncryptionKeyUrl, res.image.scr);
+            return participants[2].spark.encryption.decryptScr(board.defaultEncryptionKeyUrl, res.image.scr);
           })
-          .then((decryptedScr) => participants[1].spark.encryption.download(decryptedScr))
+          .then((decryptedScr) => participants[2].spark.encryption.download(decryptedScr))
           .then((file) => assert(fh.isMatchingFile(file, fixture)));
       });
     });
@@ -165,7 +165,7 @@ describe(`plugin-board`, () => {
       });
 
       it(`allows others to download image`, () => {
-        return participants[1].spark.encryption.download(testScr)
+        return participants[2].spark.encryption.download(testScr)
           .then((downloadedFile) => assert(fh.isMatchingFile(downloadedFile, fixture)));
       });
     });

--- a/packages/plugin-board/test/integration/spec/board.js
+++ b/packages/plugin-board/test/integration/spec/board.js
@@ -70,7 +70,7 @@ describe(`plugin-board`, () => {
     })));
 
     describe(`#getChannel`, () => {
-      it(`gets the channal metadata`, () => {
+      it(`gets the channel metadata`, () => {
         return participants[0].spark.board.getChannel(board)
           .then((channel) => {
             assert.property(channel, `kmsResourceUrl`);

--- a/packages/plugin-board/test/integration/spec/board.js
+++ b/packages/plugin-board/test/integration/spec/board.js
@@ -30,7 +30,7 @@ describe(`plugin-board`, () => {
   describe(`service`, () => {
     let board, conversation, fixture, participants;
 
-    before(`create users`, () => testUsers.create({count: 2})
+    before(`create users`, () => testUsers.create({count: 3})
       .then((users) => {
         participants = users;
 
@@ -53,7 +53,7 @@ describe(`plugin-board`, () => {
         return conversation;
       }));
 
-    before(`create channel (board)`, () => participants[0].spark.board.createChannel({aclUrl: conversation.id})
+    before(`create channel (board)`, () => participants[0].spark.board.createChannel(conversation)
       .then((channel) => {
         board = channel;
         return channel;
@@ -68,6 +68,22 @@ describe(`plugin-board`, () => {
     after(`disconnect mercury`, () => Promise.all(map(participants, (participant) => {
       return participant.spark.mercury.disconnect();
     })));
+
+    describe(`#getChannel`, () => {
+      it(`gets the channal metadata`, () => {
+        return participants[0].spark.board.getChannel(board)
+          .then((channel) => {
+            assert.property(channel, `kmsResourceUrl`);
+            assert.property(channel, `aclUrl`);
+
+            assert.equal(channel.channelUrl, board.channelUrl);
+            assert.equal(channel.aclUrlLink, conversation.aclUrl);
+            assert.notEqual(channel.kmsResourceUrl, conversation.kmsResourceObjectUrl);
+            assert.notEqual(channel.aclUrl, conversation.aclUrl);
+            assert.notEqual(channel.defaultEncryptionKeyUrl, conversation.defaultActivityEncryptionKeyUrl);
+          });
+      });
+    });
 
     describe(`#_uploadImage()`, () => {
 
@@ -152,7 +168,7 @@ describe(`plugin-board`, () => {
     describe(`#getChannels`, () => {
 
       it(`retrieves a newly created board for a specified conversation within a single page`, () => {
-        return participants[0].spark.board.getChannels({conversationId: conversation.id})
+        return participants[0].spark.board.getChannels(conversation)
           .then((getChannelsResp) => {
             const channelFound = find(getChannelsResp.items, {channelId: board.channelId});
             assert.isDefined(channelFound);
@@ -165,8 +181,7 @@ describe(`plugin-board`, () => {
         let numChannelsToAdd = 0;
         const pageLimit = 50;
 
-        return participants[0].spark.board.getChannels({
-          conversationId: conversation.id,
+        return participants[0].spark.board.getChannels(conversation, {
           channelsLimit: 100
         })
           .then((res) => {
@@ -179,17 +194,14 @@ describe(`plugin-board`, () => {
             const promises = [];
 
             for (let i = 0; i < numChannelsToAdd; i++) {
-              promises.push(participants[0].spark.board.createChannel({
-                aclUrl: conversation.id
-              }));
+              promises.push(participants[0].spark.board.createChannel(conversation));
             }
             return Promise.all(promises);
           })
 
           // get boards, page 1
           .then(() => {
-            return participants[0].spark.board.getChannels({
-              conversationId: conversation.id,
+            return participants[0].spark.board.getChannels(conversation, {
               channelsLimit: pageLimit
             });
           })
@@ -209,7 +221,7 @@ describe(`plugin-board`, () => {
 
     describe(`#getContents()`, () => {
 
-      after(() => participants[0].spark.board.deleteAllContent(board));
+      afterEach(() => participants[0].spark.board.deleteAllContent(board));
 
       it(`adds and gets contents from the specified board`, () => {
         const contents = [{type: `curve`}];
@@ -219,7 +231,7 @@ describe(`plugin-board`, () => {
         }];
 
         return participants[0].spark.board.deleteAllContent(board)
-          .then(() => participants[0].spark.board.addContent(conversation, board, data))
+          .then(() => participants[0].spark.board.addContent(board, data))
           .then(() => participants[0].spark.board.getContents(board))
           .then((contentPage) => {
             assert.equal(contentPage.length, data.length);
@@ -227,6 +239,45 @@ describe(`plugin-board`, () => {
             assert.equal(contentPage.items[0].type, data[0].type);
           })
           .then(() => participants[0].spark.board.deleteAllContent(board));
+      });
+
+      it(`allows other people to read contents`, () => {
+        const contents = [{type: `curve`, points: [1, 2, 3, 4]}];
+        const data = [{
+          type: contents[0].type,
+          payload: JSON.stringify(contents[0])
+        }];
+
+        return participants[0].spark.board.addContent(board, data)
+          .then(() => {
+            return participants[1].spark.board.getContents(board);
+          })
+          .then((contentPage) => {
+            assert.equal(contentPage.length, data.length);
+            assert.equal(contentPage.items[0].payload, data[0].payload);
+            return participants[2].spark.board.getContents(board);
+          })
+          .then((contentPage) => {
+            assert.equal(contentPage.length, data.length);
+            assert.equal(contentPage.items[0].payload, data[0].payload);
+          });
+      });
+
+      it(`allows other people to write contents`, () => {
+        const contents = [{type: `curve`, points: [1, 2, 3, 4]}];
+        const data = [{
+          type: contents[0].type,
+          payload: JSON.stringify(contents[0])
+        }];
+
+        return participants[2].spark.board.addContent(board, data)
+          .then(() => {
+            return participants[1].spark.board.getContents(board);
+          })
+          .then((contentPage) => {
+            assert.equal(contentPage.length, data.length);
+            assert.equal(contentPage.items[0].payload, data[0].payload);
+          });
       });
 
       describe(`handles large data sets`, () => {
@@ -240,9 +291,7 @@ describe(`plugin-board`, () => {
             });
         });
 
-        before(`create contents`, () => participants[0].spark.board.addContent(conversation, board, tonsOfContents));
-
-        after(() => participants[0].spark.board.deleteAllContent(board));
+        beforeEach(`create contents`, () => participants[0].spark.board.addContent(board, tonsOfContents));
 
         it(`using the default page limit`, () => participants[0].spark.board.getContents(board)
           .then((res) => {
@@ -294,14 +343,14 @@ describe(`plugin-board`, () => {
           }
         ];
 
-        return participants[0].spark.board.addContent(conversation, channel, data)
+        return participants[0].spark.board.addContent(channel, data)
           .then(() => participants[0].spark.board.deleteAllContent(channel))
           .then(() => participants[0].spark.board.getContents(channel))
           .then((res) => {
             assert.lengthOf(res, 0);
             return res;
           })
-          .then(() => participants[0].spark.board.addContent(conversation, channel, data))
+          .then(() => participants[0].spark.board.addContent(channel, data))
           .then((res) => {
             assert.lengthOf(res[0].items, 2);
             const content = res[0].items[0];

--- a/packages/plugin-board/test/integration/spec/realtime.js
+++ b/packages/plugin-board/test/integration/spec/realtime.js
@@ -46,7 +46,7 @@ describe(`plugin-board`, () => {
         return conversation;
       }));
 
-    before(`create channel (board)`, () => participants[0].spark.board.createChannel({aclUrl: conversation.id})
+    before(`create channel (board)`, () => participants[0].spark.board.createChannel(conversation)
       .then((channel) => {
         board = channel;
         return channel;
@@ -135,7 +135,7 @@ describe(`plugin-board`, () => {
 
           // do not return promise because we want done() to be called on
           // board.activity
-          participants[0].spark.board.realtime.publish(conversation, data);
+          participants[0].spark.board.realtime.publish(board, data);
         });
       });
 
@@ -178,7 +178,7 @@ describe(`plugin-board`, () => {
 
           // do not return promise because we want done() to be called on
           // board.activity
-          participants[0].spark.board.realtime.publish(conversation, data);
+          participants[0].spark.board.realtime.publish(board, data);
         });
       });
     });

--- a/packages/plugin-board/test/integration/spec/realtime.js
+++ b/packages/plugin-board/test/integration/spec/realtime.js
@@ -143,7 +143,7 @@ describe(`plugin-board`, () => {
         let testScr;
 
         it(`uploads file to spark files which includes loc`, () => {
-          return participants[1].spark.board._uploadImage(conversation, fixture)
+          return participants[1].spark.board._uploadImage(board, fixture)
             .then((scr) => {
               assert.property(scr, `loc`);
               testScr = scr;

--- a/packages/plugin-board/test/unit/spec/board.js
+++ b/packages/plugin-board/test/unit/spec/board.js
@@ -153,7 +153,7 @@ describe(`plugin-board`, () => {
     });
 
     it(`requests PATCH to board service`, () => {
-      return spark.board.setSnapshotImage(conversation, channel, image)
+      return spark.board.setSnapshotImage(channel, image)
         .then(() => {
           assert.calledWith(spark.request, sinon.match({
             method: `PATCH`,
@@ -166,7 +166,7 @@ describe(`plugin-board`, () => {
                 width: image.width,
                 mimeType: `image/png`,
                 scr: `encryptedFoo`,
-                encryptionKeyUrl: conversation.defaultActivityEncryptionKeyUrl,
+                encryptionKeyUrl: channel.defaultEncryptionKeyUrl,
                 fileSize: image.size
               }
             }

--- a/packages/plugin-board/test/unit/spec/realtime.js
+++ b/packages/plugin-board/test/unit/spec/realtime.js
@@ -56,13 +56,13 @@ describe(`plugin-board`, () => {
         }
       };
 
-      const conv = {
-        defaultActivityEncryptionKeyUrl: fakeURL
+      const channel = {
+        defaultEncryptionKeyUrl: fakeURL
       };
 
       beforeEach(() => {
         sinon.stub(uuid, `v4`).returns(`stubbedUUIDv4`);
-        return spark.board.realtime.publish(conv, message);
+        return spark.board.realtime.publish(channel, message);
       });
 
       afterEach(() => {

--- a/src/client/services/board/board.js
+++ b/src/client/services/board/board.js
@@ -7,7 +7,6 @@
 
 /* eslint-env browser */
 
-var assign = require('lodash.assign');
 var isarray = require('lodash.isarray');
 var Persistence = require('./persistence');
 var Realtime = require('./realtime');
@@ -100,9 +99,7 @@ var BoardService = SparkBase.extend({
    * @returns {Promise<Board~EncryptedChannel>}
    */
   encryptChannel: function encryptChannel(channel, options) {
-    options = assign({
-      key: null
-    }, options);
+    options = options || {};
 
     return Promise.resolve(options.key || this.spark.encryption.getUnusedKey())
       .then(function encryptKmsMessage(key) {

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -48,13 +48,12 @@ var PersistenceService = SparkBase.extend({
    * Uploads image to spark files and adds SCR + downalodUrl to the persistence
    * service
    * @memberof Board.PersistenceService
-   * @param  {Conversation~ConversationObject} conversation
    * @param  {Board~Channel} channel
    * @param  {File} image - image to be uploaded
    * @return {Promise<Board~Content>}
    */
-  addImage: function addImage(conversation, channel, image) {
-    return this.spark.board._uploadImage(conversation, image)
+  addImage: function addImage(channel, image) {
+    return this.spark.board._uploadImage(channel, image)
       .then(function addContent(scr) {
         return this.spark.board.persistence.addContent(channel, [{
           mimeType: image.type,
@@ -69,17 +68,16 @@ var PersistenceService = SparkBase.extend({
   /**
    * Set a snapshot image for a board
    *
-   * @param {Conversation} conversation - the current conversation that the board belongs
    * @param {Board~Channel} channel
    * @param {File} image
    * @returns {Promise<Board~Channel>}
    */
-  setSnapshotImage: function setSnapshotImage(conversation, channel, image) {
+  setSnapshotImage: function setSnapshotImage(channel, image) {
     var imageScr;
-    return this.spark.board._uploadImage(conversation, image)
+    return this.spark.board._uploadImage(channel, image, {hiddenSpace: true})
       .then(function encryptScr(scr) {
         imageScr = scr;
-        return this.spark.encryption.encryptScr(imageScr, conversation.defaultActivityEncryptionKeyUrl);
+        return this.spark.encryption.encryptScr(imageScr, channel.defaultEncryptionKeyUrl);
       }.bind(this))
       .then(function attachEncryptedScr(encryptedScr) {
         imageScr.encryptedScr = encryptedScr;
@@ -93,7 +91,7 @@ var PersistenceService = SparkBase.extend({
             width: image.width || 1600,
             mimeType: image.type || 'image/png',
             scr: imageScr.encryptedScr,
-            encryptionKeyUrl: conversation.defaultActivityEncryptionKeyUrl,
+            encryptionKeyUrl: channel.defaultEncryptionKeyUrl,
             fileSize: image.size
           }
         };

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -118,10 +118,6 @@ var PersistenceService = SparkBase.extend({
    * @return {Promise<Board~Channel>}
    */
   createChannel: function createChannel(conversation, channel) {
-    if (!channel) {
-      channel = {};
-    }
-
     return this._encryptChannel(conversation, channel)
       .then(function requestCreateChannel(preppedChannel) {
         return this.spark.request({
@@ -136,7 +132,16 @@ var PersistenceService = SparkBase.extend({
       });
   },
 
-  _encryptChannel: function _prepareChannel(conversation, channel) {
+  _encryptChannel: function _encryptChannel(conversation, channel) {
+    channel = this._prepareChannel(conversation, channel);
+    return this.spark.board.encryptChannel(channel);
+  },
+
+  _prepareChannel: function _prepareChannel(conversation, channel) {
+    if (!channel) {
+      channel = {};
+    }
+
     channel.aclUrlLink = conversation.aclUrl;
     channel.kmsMessage = {
       method: 'create',
@@ -145,7 +150,7 @@ var PersistenceService = SparkBase.extend({
       keyUris: []
     };
 
-    return this.spark.board.encryptChannel(channel);
+    return channel;
   },
 
   /**

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -8,7 +8,6 @@
 var assign = require('lodash.assign');
 var SparkBase = require('../../../../lib/spark-base');
 var chunk = require('lodash.chunk');
-var last = require('lodash.last');
 var pick = require('lodash.pick');
 var promiseSeries = require('es6-promise-series');
 

--- a/src/client/services/board/realtime/realtime.js
+++ b/src/client/services/board/realtime/realtime.js
@@ -38,20 +38,20 @@ var RealtimeService = Mercury.extend({
   /**
     * Sends the message via the socket. Assumes that the message is already properly formatted
     * @memberof Board.RealtimeService
-    * @param {Conversation} conversation
-    * @param {string} message   Contains the un-encrypted message to send.
+    * @param {Board~Channel} channel
+    * @param {string} message Contains the un-encrypted message to send.
     * @returns {Promise<Board~Content>}
     */
-  publish: function publish(conversation, message) {
+  publish: function publish(channel, message) {
     var encryptionPromise;
     var contentType = 'STRING';
 
     if (message.payload.scr) {
       contentType = 'FILE';
-      encryptionPromise = this.spark.board.encryptSingleFileContent(conversation.defaultActivityEncryptionKeyUrl, message.payload);
+      encryptionPromise = this.spark.board.encryptSingleFileContent(channel.defaultEncryptionKeyUrl, message.payload);
     }
     else {
-      encryptionPromise = this.spark.board.encryptSingleContent(conversation.defaultActivityEncryptionKeyUrl, message.payload);
+      encryptionPromise = this.spark.board.encryptSingleContent(channel.defaultEncryptionKeyUrl, message.payload);
     }
 
     return encryptionPromise

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -93,14 +93,13 @@ describe('Services', function() {
       return ensureConversation()
         .then(function createBoard() {
           var data = {
-            aclUrl: conversation.id,
             properties: {
               darkTheme: false
             }
           };
           if (!board) {
             console.log('Creating new board');
-            return party.spock.spark.board.persistence.createChannel(data)
+            return party.spock.spark.board.persistence.createChannel(conversation, data)
               .then(function(w) {
                 board = w;
                 console.log('created new board: ', board);
@@ -219,7 +218,7 @@ describe('Services', function() {
 
             // do not return promise because we want done() to be called on
             // board.activity
-            party.spock.spark.board.realtime.publish(conversation, data);
+            party.spock.spark.board.realtime.publish(board, data);
           });
         });
       });
@@ -274,7 +273,7 @@ describe('Services', function() {
 
             // do not return promise because we want done() to be called on
             // board.activity
-            party.spock.spark.board.realtime.publish(conversation, data);
+            party.spock.spark.board.realtime.publish(board, data);
           });
         });
       });
@@ -315,7 +314,6 @@ describe('Services', function() {
         });
 
         it('uploads image to spark files', function() {
-
           return party.mccoy.spark.board.persistence.addImage(conversation, board, fixture.png)
             .then(function(fileContent) {
               testContent = fileContent[0].items[0];
@@ -327,7 +325,6 @@ describe('Services', function() {
         });
 
         it('adds to presistence', function() {
-
           return party.mccoy.spark.board.persistence.getAllContent(board)
             .then(function(allContents) {
               var imageContent = find(allContents, {contentId: testContent.contentId});
@@ -396,7 +393,43 @@ describe('Services', function() {
             payload: JSON.stringify(contents[0])
           }];
 
-          return party.mccoy.spark.board.persistence.addContent(conversation, board, data)
+          return party.mccoy.spark.board.persistence.addContent(board, data)
+            .then(function() {
+              return party.mccoy.spark.board.persistence.getAllContent(board);
+            })
+            .then(function(res) {
+              assert.equal(res[0].payload, data[0].payload);
+            });
+        });
+
+        it('allows other people to read contents', function() {
+          var contents = [{type: 'curve', points: [1,2,3,4]}];
+          var data = [{
+            type: contents[0].type,
+            payload: JSON.stringify(contents[0])
+          }];
+
+          return party.spock.spark.board.persistence.addContent(board, data)
+            .then(function() {
+              return party.mccoy.spark.board.persistence.getAllContent(board);
+            })
+            .then(function(res) {
+              assert.equal(res[0].payload, data[0].payload);
+              return party.checkov.spark.board.persistence.getAllContent(board);
+            })
+            .then(function(res) {
+              assert.equal(res[0].payload, data[0].payload);
+            });
+        });
+
+        it('allows other people to write contents', function() {
+          var contents = [{type: 'curve', points: [2,2,4,4]}];
+          var data = [{
+            type: contents[0].type,
+            payload: JSON.stringify(contents[0])
+          }];
+
+          return party.checkov.spark.board.persistence.addContent(board, data)
             .then(function() {
               return party.mccoy.spark.board.persistence.getAllContent(board);
             })
@@ -407,7 +440,7 @@ describe('Services', function() {
 
         it('can deal with tons of contents by pagination', function() {
           var tonsOfContents = generateTonsOfContents(400);
-          return party.mccoy.spark.board.persistence.addContent(conversation, board, tonsOfContents)
+          return party.mccoy.spark.board.persistence.addContent(board, tonsOfContents)
             .then(function() {
               return party.mccoy.spark.board.persistence.getAllContent(board, {contentsLimit: 150});
             })
@@ -451,7 +484,7 @@ describe('Services', function() {
               payload: JSON.stringify(contents[1])
             }
           ];
-          return party.mccoy.spark.board.persistence.addContent(conversation, channel, data)
+          return party.mccoy.spark.board.persistence.addContent(channel, data)
             .then(function() {
               return party.mccoy.spark.board.persistence.deleteAllContent(channel);
             })
@@ -463,7 +496,7 @@ describe('Services', function() {
               return res;
             })
             .then(function() {
-              return party.mccoy.spark.board.persistence.addContent(conversation, channel, data);
+              return party.mccoy.spark.board.persistence.addContent(channel, data);
             })
             .then(function(res) {
               assert.equal(res[0].items.length, 2);
@@ -489,7 +522,7 @@ describe('Services', function() {
         });
 
         it('retrieves a newly created board for a specified conversation within a single page', function() {
-          return party.spock.spark.board.persistence.getChannels({conversationId: conversation.id})
+          return party.spock.spark.board.persistence.getChannels(conversation)
             .then(function(getChannelsResp) {
               var channelFound = find(getChannelsResp.items, {channelId: board.channelId});
               assert.isDefined(channelFound);
@@ -510,15 +543,12 @@ describe('Services', function() {
               var promises = [];
 
               for (var i = 0; i < pageLimit + 1; i++) {
-                promises.push(party.spock.spark.board.persistence.createChannel({
-                  aclUrl: conversation.id
-                }));
+                promises.push(party.spock.spark.board.persistence.createChannel(conversation, {}));
               }
               return Promise.all(promises);
             })
             .then(function() {
-              return party.spock.spark.board.persistence.getChannels({
-                conversationId: conversation.id,
+              return party.spock.spark.board.persistence.getChannels(conversation, {
                 channelsLimit: pageLimit
               });
             })

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -133,7 +133,10 @@ describe('Services', function() {
       return landingparty.beamDown(party)
         .then(function() {
           party.spock.spark.feature.setFeature('developer', 'files-acl-write', true);
-          party.mccoy.spark.feature.setFeature('developer', 'files-acl-write', true);
+          return party.checkov.spark.feature.setFeature('developer', 'files-acl-write', true);
+        })
+        .then(function() {
+          return party.mccoy.spark.feature.setFeature('developer', 'files-acl-write', true);
         });
     });
 
@@ -153,7 +156,7 @@ describe('Services', function() {
             return party.mccoy.spark.board._uploadImage(board, fixture.png);
           })
           .then(function(scr) {
-            return party.spock.spark.encryption.download(scr);
+            return party.checkov.spark.encryption.download(scr);
           })
           .then(function(file) {
             assert(fixtures.isMatchingFile(file, fixture.png));
@@ -368,7 +371,7 @@ describe('Services', function() {
         });
 
         it('allows others to download the image', function() {
-          return party.spock.spark.encryption.download(testScr)
+          return party.checkov.spark.encryption.download(testScr)
             .then(function(file) {
               assert(fixtures.isMatchingFile(file, fixture.png));
             });
@@ -404,10 +407,10 @@ describe('Services', function() {
             .then(function(res) {
               assert.deepEqual(res.image, imageRes);
               // ensure others can download the image
-              return party.spock.spark.encryption.decryptScr(res.image.scr, board.defaultEncryptionKeyUrl);
+              return party.checkov.spark.encryption.decryptScr(res.image.scr, board.defaultEncryptionKeyUrl);
             })
             .then(function(decryptedScr) {
-              return party.spock.spark.encryption.download(decryptedScr);
+              return party.checkov.spark.encryption.download(decryptedScr);
             })
             .then(function(file) {
               assert(fixtures.isMatchingFile(file, fixture.png));

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -280,7 +280,7 @@ describe('Services', function() {
     });
 
     describe('Persistence', function() {
-      describe('#getChannel', function() {
+      describe('#getChannel()', function() {
         before(function() {
           return ensureBoard();
         });

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -280,6 +280,26 @@ describe('Services', function() {
     });
 
     describe('Persistence', function() {
+      describe('#getChannel', function() {
+        before(function() {
+          return ensureBoard();
+        });
+
+        it('gets the channel metadata', function() {
+          return party.mccoy.spark.board.persistence.getChannel(board)
+            .then(function(channel) {
+              assert.property(channel, 'kmsResourceUrl');
+              assert.property(channel, 'aclUrl');
+
+              assert.equal(channel.channelUrl, board.channelUrl);
+              assert.equal(channel.aclUrlLink, conversation.aclUrl);
+              assert.notEqual(channel.kmsResourceUrl, conversation.kmsResourceObjectUrl);
+              assert.notEqual(channel.aclUrl, conversation.aclUrl);
+              assert.notEqual(channel.defaultEncryptionKeyUrl, conversation.defaultActivityEncryptionKeyUrl);
+            });
+        });
+      });
+
       describe('#ping()', function() {
         it('pings persistence board service', function() {
           return party.mccoy.spark.board.persistence.ping()

--- a/test/unit/spec/services/board/board.js
+++ b/test/unit/spec/services/board/board.js
@@ -21,9 +21,11 @@ describe('Services', function() {
     var fakeURL = 'fakeURL';
     var file = 'dataURL://base64;';
 
-    var conversation = {
-      id: 'superUniqueId',
-      defaultActivityEncryptionKeyUrl: fakeURL
+    var channel = {
+      channelId: 'boardId',
+      channelUrl: '/channels/boardId',
+      aclUrlLink: 'aclUrlLink',
+      defaultEncryptionKeyUrl: 'key'
     };
 
     before(function() {
@@ -68,26 +70,26 @@ describe('Services', function() {
     describe('#_uploadImage()', function() {
 
       before(function() {
-        sinon.stub(spark.board, '_uploadImageToSparkFiles', sinon.stub().returns(Promise.resolve({
+        sinon.stub(spark.board, '_uploadImageToBoardSpace', sinon.stub().returns(Promise.resolve({
           downloadUrl: fakeURL
         })));
-        return spark.board._uploadImage(conversation, file);
+        return spark.board._uploadImage(channel, file);
       });
 
       after(function() {
-        spark.board._uploadImageToSparkFiles.restore();
+        spark.board._uploadImageToBoardSpace.restore();
       });
 
       it('encrypts binary file', function() {
         assert.calledWith(spark.encryption.encryptBinary, file);
       });
 
-      it('uploads to spark files', function() {
-        assert.calledWith(spark.board._uploadImageToSparkFiles, conversation, encryptedData);
+      it('uploads to board space', function() {
+        assert.calledWith(spark.board._uploadImageToBoardSpace, channel, encryptedData);
       });
     });
 
-    describe('#_uploadImageToSparkFiles()', function() {
+    describe('#_uploadImageToBoardSpace()', function() {
 
       afterEach(function() {
         spark.client.upload.reset();
@@ -100,7 +102,7 @@ describe('Services', function() {
           byteLength: 2222
         };
 
-        return spark.board._uploadImageToSparkFiles(conversation, blob)
+        return spark.board._uploadImageToBoardSpace(channel, blob)
           .then(function() {
             assert.calledWith(spark.client.upload, sinon.match({
               phases: {
@@ -123,7 +125,7 @@ describe('Services', function() {
           byteLength: 2222
         };
 
-        return spark.board._uploadImageToSparkFiles(conversation, blob)
+        return spark.board._uploadImageToBoardSpace(channel, blob)
           .then(function() {
             assert.calledWith(spark.client.upload, sinon.match({
               phases: {
@@ -145,7 +147,7 @@ describe('Services', function() {
           byteLength: 2222
         };
 
-        return spark.board._uploadImageToSparkFiles(conversation, blob)
+        return spark.board._uploadImageToBoardSpace(channel, blob)
           .then(function() {
             assert.calledWith(spark.client.upload, sinon.match({
               phases: {

--- a/test/unit/spec/services/board/persistence.js
+++ b/test/unit/spec/services/board/persistence.js
@@ -241,7 +241,7 @@ describe('Services', function() {
         });
 
         it('requests PATCH to board service', function() {
-          return spark.board.persistence.setSnapshotImage(conversation, channel, image)
+          return spark.board.persistence.setSnapshotImage(channel, image)
             .then(function() {
               assert.calledWith(spark.request, sinon.match({
                 method: 'PATCH',
@@ -254,7 +254,7 @@ describe('Services', function() {
                     width: image.width,
                     mimeType: 'image/png',
                     scr: 'encryptedFoo',
-                    encryptionKeyUrl: conversation.defaultActivityEncryptionKeyUrl,
+                    encryptionKeyUrl: channel.defaultEncryptionKeyUrl,
                     fileSize: image.size
                   }
                 }

--- a/test/unit/spec/services/board/realtime.js
+++ b/test/unit/spec/services/board/realtime.js
@@ -54,15 +54,15 @@ describe('Services', function() {
           envelope: {
           }
         };
-        var conv = {
-          defaultActivityEncryptionKeyUrl: fakeURL
+        var channel = {
+          defaultEncryptionKeyUrl: fakeURL
         };
 
         var rcpnts = [{alertType:'none', headers: {}, route: boundObject[0]}];
 
         beforeEach(function() {
           sinon.stub(uuid, 'v4').returns('stubbedUUIDv4');
-          return spark.board.realtime.publish(conv, message);
+          return spark.board.realtime.publish(channel, message);
         });
 
         afterEach(function() {


### PR DESCRIPTION
Newly created board will have its own ACL and encryption key instead of using conversation ID. A board's ACL parent will be the conversation ACL URL.

Changes made to
Persistence:
- createChannel - takes in conversation and use the aclUrl as aclUrlLink (parent acl)
- addContent - no longer needs conversation's encryptionKeyUrl but rather use board's encryptionKeyUrl instead
- addImage - uploads to a space created by board service instead of using conversation's space
- setSnapshotImage - same as addImage (upload to board space)
- getChannels - takes in conversation and query using aclUrl

Realtime:
- publish - now takes in channel as well (to get the encryption key)
