### PR TITLE
feat(board): Support image file content

### DIFF
--- a/packages/plugin-board/test/integration/spec/board.js
+++ b/packages/plugin-board/test/integration/spec/board.js
@@ -143,7 +143,8 @@ describe(`plugin-board`, () => {
             assert.equal(testContent.type, `FILE`, `content type should be image`);
             assert.property(testContent, `contentUrl`, `content should contain contentId property`);
             assert.property(testContent, `channelUrl`, `content should contain contentUrl property`);
-            assert.property(testContent, `scr`, `content should contain scr property`);
+            assert.property(testContent, `file`, `content should contain file property`);
+            assert.property(testContent.file, `scr`, `content file should contain scr property`);
           });
       });
 
@@ -152,10 +153,11 @@ describe(`plugin-board`, () => {
           .then((allContents) => {
             const imageContent = find(allContents.items, {contentId: testContent.contentId});
             assert.isDefined(imageContent);
-            assert.property(imageContent, `scr`);
+            assert.property(imageContent, `file`);
+            assert.property(imageContent.file, `scr`);
             assert.equal(imageContent.displayName, `sample-image-small-one.png`);
-            testScr = imageContent.scr;
-            return imageContent.scr;
+            testScr = imageContent.file.scr;
+            return imageContent.file.scr;
           });
       });
 

--- a/packages/plugin-board/test/integration/spec/realtime.js
+++ b/packages/plugin-board/test/integration/spec/realtime.js
@@ -159,7 +159,10 @@ describe(`plugin-board`, () => {
             },
             payload: {
               displayName: `image.png`,
-              scr: testScr
+              type: `FILE`,
+              file: {
+                scr: testScr
+              }
             }
           };
 
@@ -167,7 +170,7 @@ describe(`plugin-board`, () => {
           // same data that was sent.
           participants[1].spark.board.realtime.once(`event:board.activity`, ({data}) => {
             assert.equal(data.contentType, `FILE`);
-            assert.equal(data.payload.scr.loc, testScr.loc);
+            assert.equal(data.payload.file.scr.loc, testScr.loc);
             assert.equal(data.payload.displayName, `image.png`);
             done();
           });

--- a/packages/plugin-board/test/unit/spec/board.js
+++ b/packages/plugin-board/test/unit/spec/board.js
@@ -366,8 +366,10 @@ describe(`plugin-board`, () => {
 
       const imageContents = [{
         displayName: `FileName`,
-        scr: {
-          loc: fakeURL
+        file: {
+          scr: {
+            loc: fakeURL
+          }
         }
       }];
 
@@ -430,9 +432,11 @@ describe(`plugin-board`, () => {
           type: `FILE`,
           payload: JSON.stringify({
             type: `image`,
-            scr: `encryptedScr`,
             displayName: `encryptedDisplayName`
           }),
+          file: {
+            scr: `encryptedScr`
+          },
           encryptionKeyUrl: fakeURL
         }]
       };

--- a/packages/plugin-board/test/unit/spec/board.js
+++ b/packages/plugin-board/test/unit/spec/board.js
@@ -396,15 +396,19 @@ describe(`plugin-board`, () => {
 
     before(() => {
       sinon.stub(spark.board, `decryptSingleContent`, sinon.stub().returns(Promise.resolve({})));
+      sinon.spy(spark.board, `decryptSingleFileContent`);
     });
 
     after(() => {
       spark.board.decryptSingleContent.restore();
+      spark.board.decryptSingleFileContent.restore();
     });
 
     afterEach(() => {
       spark.board.decryptSingleContent.reset();
+      spark.board.decryptSingleFileContent.reset();
       spark.encryption.decryptScr.reset();
+      spark.encryption.decryptText.reset();
     });
 
     it(`calls decryptSingleContent when type is not image`, () => {
@@ -425,8 +429,7 @@ describe(`plugin-board`, () => {
         });
     });
 
-    it(`calls decryptSingleContent when type is FILE`, () => {
-
+    it(`calls decryptSingleFileContent when type is FILE`, () => {
       const imageContents = {
         items: [{
           type: `FILE`,
@@ -443,7 +446,27 @@ describe(`plugin-board`, () => {
 
       return spark.board.decryptContents(imageContents)
         .then(() => {
+          assert.calledOnce(spark.board.decryptSingleFileContent);
           assert.calledWith(spark.encryption.decryptText, fakeURL, `encryptedDisplayName`);
+          assert.calledWith(spark.encryption.decryptScr, fakeURL, `encryptedScr`);
+        });
+    });
+
+    it(`does not require payload when type is FILE`, () => {
+      const imageContents = {
+        items: [{
+          type: `FILE`,
+          file: {
+            scr: `encryptedScr`
+          },
+          encryptionKeyUrl: fakeURL
+        }]
+      };
+
+      return spark.board.decryptContents(imageContents)
+        .then(() => {
+          assert.calledOnce(spark.board.decryptSingleFileContent);
+          assert.calledWith(spark.encryption.decryptText, fakeURL, undefined);
           assert.calledWith(spark.encryption.decryptScr, fakeURL, `encryptedScr`);
         });
     });

--- a/packages/plugin-board/test/unit/spec/realtime.js
+++ b/packages/plugin-board/test/unit/spec/realtime.js
@@ -96,7 +96,10 @@ describe(`plugin-board`, () => {
 
       beforeEach(() => {
         sinon.stub(uuid, `v4`).returns(`stubbedUUIDv4`);
-        return spark.board.realtime.publishEncrypted(`fakeURL`, `encryptedData`);
+        return spark.board.realtime.publishEncrypted({
+          encryptedData: `encryptedData`,
+          encryptedKeyUrl: `fakeURL`
+        }, `STRING`);
       });
 
       afterEach(() => {
@@ -116,6 +119,7 @@ describe(`plugin-board`, () => {
             route: `binding`
           }],
           data: {
+            contentType: `STRING`,
             eventType: `board.activity`,
             envelope: {
               encryptionKeyUrl: `fakeURL`

--- a/src/client/services/board/board.js
+++ b/src/client/services/board/board.js
@@ -182,7 +182,7 @@ var BoardService = SparkBase.extend({
       .then(function returnEncryptedContent(encryptedDisplayName) {
         var metadata = {
           displayName: encryptedDisplayName
-        }
+        };
 
         return {
           file: content.file,

--- a/src/client/services/board/board.js
+++ b/src/client/services/board/board.js
@@ -7,12 +7,14 @@
 
 /* eslint-env browser */
 
+var assign = require('lodash.assign');
+var defaults = require('lodash.defaults');
 var isarray = require('lodash.isarray');
 var Persistence = require('./persistence');
+var pick = require('lodash.pick');
 var Realtime = require('./realtime');
 var reduce = require('lodash.reduce');
 var SparkBase = require('../../../lib/spark-base');
-var defaults = require('lodash.defaults');
 
 /**
  * @class
@@ -39,7 +41,7 @@ var BoardService = SparkBase.extend({
       var decryptPromise;
 
       if (content.type === 'FILE') {
-        decryptPromise =  this.decryptSingleFileContent(content.payload, content.encryptionKeyUrl);
+        decryptPromise =  this.decryptSingleFileContent(content, content.encryptionKeyUrl);
       }
       else {
         decryptPromise = this.decryptSingleContent(content.payload, content.encryptionKeyUrl);
@@ -71,21 +73,25 @@ var BoardService = SparkBase.extend({
   /**
    * Decryts a single FILE content object
    * @memberof Board.BoardService
-   * @param  {string} encryptedData
+   * @param  {string} encryptedFileContent
    * @param  {string} encryptionKeyUrl
    * @return {Promise<Board~Content>}
    */
-  decryptSingleFileContent: function _decryptSingleFileContent(encryptedData, encryptionKeyUrl) {
-    var payload = JSON.parse(encryptedData);
+  decryptSingleFileContent: function _decryptSingleFileContent(encryptedFileContent, encryptionKeyUrl) {
+    var metadata = {};
 
-    return this.spark.encryption.decryptScr(payload.scr, encryptionKeyUrl)
+    if (encryptedFileContent.payload) {
+      metadata = JSON.parse(encryptedFileContent.payload);
+    }
+
+    return this.spark.encryption.decryptScr(encryptedFileContent.file.scr, encryptionKeyUrl)
       .then(function setScrInPayload(scr) {
-        payload.scr = scr;
-        return this.spark.encryption.decryptText(payload.displayName, encryptionKeyUrl);
+        encryptedFileContent.file.scr = scr;
+        return this.spark.encryption.decryptText(metadata.displayName, encryptionKeyUrl);
       }.bind(this))
       .then(function setDisplayNameInPayload(displayName) {
-        payload.displayName = displayName;
-        return payload;
+        encryptedFileContent.displayName = displayName;
+        return encryptedFileContent;
       });
   },
 
@@ -121,7 +127,7 @@ var BoardService = SparkBase.extend({
       var contentType = 'STRING';
 
       // the existence of an scr will determine if the content is a FILE.
-      if (content.scr) {
+      if (content.file) {
         contentType = 'FILE';
         encryptionPromise = this.encryptSingleFileContent(encryptionKeyUrl, content);
       }
@@ -131,12 +137,14 @@ var BoardService = SparkBase.extend({
 
       return encryptionPromise
         .then(function createEncryptedContent(res) {
-          return {
-            device: this.spark.device.deviceType,
-            type: contentType,
-            encryptionKeyUrl: encryptionKeyUrl,
-            payload: res.encryptedData
-          };
+          return assign({
+              device: this.spark.device.deviceType,
+              type: contentType,
+              encryptionKeyUrl: encryptionKeyUrl,
+              payload: res.encryptedData
+            },
+            pick(res, 'file')
+          );
         }.bind(this));
     }, this));
   },
@@ -166,16 +174,19 @@ var BoardService = SparkBase.extend({
    * @return {Promise<Board~Content>}
    */
   encryptSingleFileContent: function _encryptSingleFileContent(encryptionKeyUrl, content) {
-    return this.spark.encryption.encryptScr(content.scr, encryptionKeyUrl)
+    return this.spark.encryption.encryptScr(content.file.scr, encryptionKeyUrl)
       .then(function encryptDisplayName(encryptedScr) {
-        content.scr = encryptedScr;
+        content.file.scr = encryptedScr;
         return this.spark.encryption.encryptText(content.displayName, encryptionKeyUrl);
       }.bind(this))
-      .then(function stringifyContent(displayName) {
-        content.displayName = displayName;
+      .then(function returnEncryptedContent(encryptedDisplayName) {
+        var metadata = {
+          displayName: encryptedDisplayName
+        }
 
         return {
-          encryptedData: JSON.stringify(content),
+          file: content.file,
+          encryptedData: JSON.stringify(metadata),
           encryptionKeyUrl: encryptionKeyUrl
         };
       });

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -56,10 +56,14 @@ var PersistenceService = SparkBase.extend({
     return this.spark.board._uploadImage(channel, image)
       .then(function addContent(scr) {
         return this.spark.board.persistence.addContent(channel, [{
-          mimeType: image.type,
-          size: image.size,
+          type: 'FILE',
           displayName: image.name,
-          scr: scr
+          file: {
+            mimeType: image.type,
+            scr: scr,
+            size: image.size,
+            url: scr.loc
+          }
         }]);
       }.bind(this));
   },

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -261,7 +261,10 @@ describe('Services', function() {
               },
               payload: {
                 displayName: 'image.png',
-                scr: testScr
+                type: 'FILE',
+                file: {
+                  scr: testScr
+                }
               }
             };
 
@@ -269,7 +272,7 @@ describe('Services', function() {
             // same data that was sent.
             party.mccoy.spark.board.realtime.once('board.activity', function(boardData) {
               assert.equal(boardData.contentType, 'FILE');
-              assert.equal(boardData.payload.scr.loc, testScr.loc);
+              assert.equal(boardData.payload.file.scr.loc, testScr.loc);
               assert.equal(boardData.payload.displayName, 'image.png');
               done();
             });
@@ -345,6 +348,7 @@ describe('Services', function() {
             .then(function(fileContent) {
               testContent = fileContent[0].items[0];
               assert.equal(testContent.type, 'FILE', 'content type should be image');
+              assert.property(testContent, 'file', 'content should contain file property');
               assert.property(testContent, 'contentId', 'content should contain contentId property');
               assert.property(testContent, 'payload', 'content should contain payload property');
               assert.property(testContent, 'encryptionKeyUrl', 'content should contain encryptionKeyUrl property');
@@ -356,10 +360,11 @@ describe('Services', function() {
             .then(function(allContents) {
               var imageContent = find(allContents, {contentId: testContent.contentId});
               assert.isDefined(imageContent);
-              assert.property(imageContent, 'scr');
+              assert.property(imageContent, 'file');
+              assert.property(imageContent.file, 'scr');
               assert.equal(imageContent.displayName, 'sample-image-small-one.png');
-              testScr = imageContent.scr;
-              return imageContent.scr;
+              testScr = imageContent.file.scr;
+              return imageContent.file.scr;
             });
         });
 

--- a/test/unit/spec/services/board/board.js
+++ b/test/unit/spec/services/board/board.js
@@ -228,15 +228,19 @@ describe('Services', function() {
 
       before(function() {
         sinon.stub(spark.board, 'decryptSingleContent', sinon.stub().returns(Promise.resolve({})));
+        sinon.spy(spark.board, 'decryptSingleFileContent');
       });
 
       after(function() {
         spark.board.decryptSingleContent.restore();
+        spark.board.decryptSingleFileContent.restore();
       });
 
       afterEach(function() {
         spark.board.decryptSingleContent.reset();
+        spark.board.decryptSingleFileContent.reset();
         spark.encryption.decryptScr.reset();
+        spark.encryption.decryptText.reset();
       });
 
       it('calls decryptSingleContent when type is not image', function() {
@@ -275,7 +279,27 @@ describe('Services', function() {
 
         return spark.board.decryptContents(imageContents)
           .then(function() {
+            assert.calledOnce(spark.board.decryptSingleFileContent);
             assert.calledWith(spark.encryption.decryptText, 'encryptedDisplayName', fakeURL);
+            assert.calledWith(spark.encryption.decryptScr, 'encryptedScr', fakeURL);
+          });
+      });
+
+      it('does not require payload when type is FILE', function() {
+        var imageContents = {
+          items: [{
+            type: 'FILE',
+            file: {
+              scr: 'encryptedScr'
+            },
+            encryptionKeyUrl: fakeURL
+          }]
+        };
+
+        return spark.board.decryptContents(imageContents)
+          .then(function() {
+            assert.calledOnce(spark.board.decryptSingleFileContent);
+            assert.calledWith(spark.encryption.decryptText, undefined, fakeURL);
             assert.calledWith(spark.encryption.decryptScr, 'encryptedScr', fakeURL);
           });
       });

--- a/test/unit/spec/services/board/board.js
+++ b/test/unit/spec/services/board/board.js
@@ -185,9 +185,10 @@ describe('Services', function() {
         }];
 
         return spark.board.encryptContents(fakeURL, curveContents)
-          .then(function() {
+          .then(function(res) {
             assert.calledWith(spark.board.encryptSingleContent, fakeURL, curveContents[0]);
             assert.notCalled(spark.encryption.encryptScr);
+            assert.equal(res[0].payload, encryptedData);
           });
       });
 
@@ -195,15 +196,19 @@ describe('Services', function() {
 
         var imageContents = [{
           displayName: 'FileName',
-          scr: {
-            loc: fakeURL
+          file: {
+            scr: {
+              loc: fakeURL
+            }
           }
         }];
 
         return spark.board.encryptContents(fakeURL, imageContents)
-          .then(function() {
+          .then(function(encryptedFiles) {
             assert.calledWith(spark.encryption.encryptScr, {loc: fakeURL}, fakeURL);
             assert.calledWith(spark.encryption.encryptText, 'FileName', fakeURL);
+            assert.equal(encryptedFiles[0].type, 'FILE');
+            assert.property(encryptedFiles[0], 'file', 'file content must have file property');
           });
       });
 
@@ -252,16 +257,18 @@ describe('Services', function() {
           });
       });
 
-      it('calls decryptSingleContent when type is FILE', function() {
+      it('calls decryptSingleFileContent when type is FILE', function() {
 
         var imageContents = {
           items: [{
             type: 'FILE',
             payload: JSON.stringify({
               type: 'image',
-              scr: 'encryptedScr',
               displayName: 'encryptedDisplayName'
             }),
+            file: {
+              scr: 'encryptedScr',
+            },
             encryptionKeyUrl: fakeURL
           }]
         };

--- a/test/unit/spec/services/board/realtime.js
+++ b/test/unit/spec/services/board/realtime.js
@@ -81,6 +81,7 @@ describe('Services', function() {
             recipients: rcpnts,
             data: {
               eventType: 'board.activity',
+              contentType: 'STRING',
               envelope: {
                 encryptionKeyUrl: 'fakeURL'
               },
@@ -95,7 +96,12 @@ describe('Services', function() {
         beforeEach(function() {
           spark.board.realtime.boardBindings = ['binding'];
           sinon.stub(uuid, 'v4').returns('stubbedUUIDv4');
-          return spark.board.realtime.publishEncrypted('fakeURL', 'encryptedData');
+          return spark.board.realtime.publishEncrypted({
+              encryptedData: 'encryptedData',
+              encryptionKeyUrl: 'fakeURL'
+            },
+            'STRING'
+          );
         });
 
         afterEach(function() {
@@ -113,12 +119,13 @@ describe('Services', function() {
             id: uuid.v4(),
             type: 'publishRequest',
             recipients: [{
-              alertType:'none',
+              alertType: 'none',
               headers: {},
               route: 'binding'
             }],
             data: {
               eventType: 'board.activity',
+              contentType: 'STRING',
               envelope: {
                 encryptionKeyUrl: 'fakeURL'
               },


### PR DESCRIPTION
Before we're adding file content to whiteboard as
```
{
  type: 'FILE',
  payload: {
    mimeType: file.type,
    fileSize: file.size,
    displayName: encryptedDisplayName
    scr: encryptedSCR
  }
}
```
The server now requires type FILE to have `file` property:
```
{
  type: 'FILE',
  payload: { // now is metadata
    displayName: encryptedDisplayName
  },
  file: {
    mimeType: file.type,
    fileSize: file.size,
    scr: encryptedSCR,
    url: scr.loc
  }
}
```