### PR TITLE
feat(mercury+board): sharing mercury web socket

### DIFF
--- a/Gruntfile.package.js
+++ b/Gruntfile.package.js
@@ -227,7 +227,8 @@ module.exports = function configureGrunt(grunt) {
         }],
         options: {
           reporters: {
-            'text-summary': {}
+            'text-summary': {},
+            html: {}
           }
         }
       }

--- a/Gruntfile.package.js
+++ b/Gruntfile.package.js
@@ -227,8 +227,7 @@ module.exports = function configureGrunt(grunt) {
         }],
         options: {
           reporters: {
-            'text-summary': {},
-            html: {}
+            'text-summary': {}
           }
         }
       }

--- a/packages/plugin-board/src/board.js
+++ b/packages/plugin-board/src/board.js
@@ -408,6 +408,64 @@ const Board = SparkPlugin.extend({
       .then((res) => res.body);
   },
 
+  /**
+   * Registers with Mercury for sharing web socket
+   * @memberof Board.BoardService
+   * @param  {Board~Channel} channel
+   * @returns {Promise<Board~Registration>}
+   */
+  registerToShareMercury(channel) {
+    const isSharingMercuryFeatureEnabled = this.spark.device.features.developer.get(`web-sharable-mercury`);
+
+    if (!this.spark.mercury.localClusterServiceUrls) {
+      return Promise.reject(new Error(`\`localClusterServiceUrls\` is not defined, make sure mercury is connected`));
+    }
+    else if (!isSharingMercuryFeatureEnabled || !isSharingMercuryFeatureEnabled.value) {
+      return Promise.reject(new Error(`\`web-sharable-mercury\` is not enabled`));
+    }
+
+    const webSocketUrl = this.spark.device.webSocketUrl;
+    const mercuryConnectionServiceClusterUrl = this.spark.mercury.localClusterServiceUrls.mercuryConnectionServiceClusterUrl;
+
+    const data = {
+      mercuryConnectionServiceClusterUrl,
+      webSocketUrl,
+      action: `REPLACE`
+    };
+
+    return this.spark.request({
+      method: `POST`,
+      api: `board`,
+      resource: `/channels/${channel.channelId}/register`,
+      body: data
+    })
+      .then((res) => res.body);
+  },
+
+  /**
+   * Remove board binding from existing mercury connection
+   * @memberof Board.BoardService
+   * @param  {Board~Channel} channel
+   * @param  {String} binding - the binding as provided in board registration
+   * @returns {Promise<Board~Registration>}
+   */
+  unregisterFromSharedMercury(channel, binding) {
+    const webSocketUrl = this.spark.device.webSocketUrl;
+    const data = {
+      binding,
+      webSocketUrl,
+      action: `REMOVE`
+    };
+
+    return this.spark.request({
+      method: `POST`,
+      api: `board`,
+      resource: `/channels/${channel.channelId}/register`,
+      body: data
+    })
+      .then((res) => res.body);
+  },
+
   _addContentChunk(channel, contentChunk) {
     return this.spark.board.encryptContents(channel.defaultEncryptionKeyUrl, contentChunk)
       .then((res) => this.spark.request({

--- a/packages/plugin-board/src/board.js
+++ b/packages/plugin-board/src/board.js
@@ -415,13 +415,13 @@ const Board = SparkPlugin.extend({
    * @returns {Promise<Board~Registration>}
    */
   registerToShareMercury(channel) {
-    const isSharingMercuryFeatureEnabled = this.spark.device.features.developer.get(`web-sharable-mercury`);
+    const isSharingMercuryFeatureEnabled = this.spark.device.features.developer.get(`web-shared-mercury`);
 
     if (!this.spark.mercury.localClusterServiceUrls) {
       return Promise.reject(new Error(`\`localClusterServiceUrls\` is not defined, make sure mercury is connected`));
     }
     else if (!isSharingMercuryFeatureEnabled || !isSharingMercuryFeatureEnabled.value) {
-      return Promise.reject(new Error(`\`web-sharable-mercury\` is not enabled`));
+      return Promise.reject(new Error(`\`web-shared-mercury\` is not enabled`));
     }
 
     const webSocketUrl = this.spark.device.webSocketUrl;

--- a/packages/plugin-board/src/board.js
+++ b/packages/plugin-board/src/board.js
@@ -433,14 +433,12 @@ const Board = SparkPlugin.extend({
           action: `REPLACE`
         };
 
-        return data;
+        return this.spark.request({
+          method: `POST`,
+          uri: `${channel.channelUrl}/register`,
+          body: data
+        });
       })
-      .then((data) => this.spark.request({
-        method: `POST`,
-        api: `board`,
-        resource: `/channels/${channel.channelId}/register`,
-        body: data
-      }))
       .then((res) => res.body);
   },
 
@@ -461,8 +459,7 @@ const Board = SparkPlugin.extend({
 
     return this.spark.request({
       method: `POST`,
-      api: `board`,
-      resource: `/channels/${channel.channelId}/register`,
+      uri: `${channel.channelUrl}/register`,
       body: data
     })
       .then((res) => res.body);

--- a/packages/plugin-board/src/board.js
+++ b/packages/plugin-board/src/board.js
@@ -435,14 +435,12 @@ const Board = SparkPlugin.extend({
 
         return data;
       })
-      .then((data) =>
-        this.spark.request({
-          method: `POST`,
-          api: `board`,
-          resource: `/channels/${channel.channelId}/register`,
-          body: data
-        })
-      )
+      .then((data) => this.spark.request({
+        method: `POST`,
+        api: `board`,
+        resource: `/channels/${channel.channelId}/register`,
+        body: data
+      }))
       .then((res) => res.body);
   },
 

--- a/packages/plugin-board/src/config.js
+++ b/packages/plugin-board/src/config.js
@@ -35,6 +35,12 @@ export default {
      * discarding it
      * @type {[type]}
      */
-    forceCloseDelay: process.env.MERCURY_FORCE_CLOSE_DELAY || 2000
+    forceCloseDelay: process.env.MERCURY_FORCE_CLOSE_DELAY || 2000,
+
+    /**
+     * The prefix for board binding when open a new socket connection
+     * @type {string}
+     */
+    mercuryBindingPrefix: `board.`
   }
 };

--- a/packages/plugin-board/src/realtime.js
+++ b/packages/plugin-board/src/realtime.js
@@ -88,7 +88,7 @@ const RealtimeService = Mercury.extend({
 
     // use mercury socket if it is shared
     // if this.socket is defined then use it instead
-    const isSharingMercuryFeatureEnabled = this.spark.device.features.developer.get(`web-sharable-mercury`);
+    const isSharingMercuryFeatureEnabled = this.spark.device.features.developer.get(`web-shared-mercury`);
     if (isSharingMercuryFeatureEnabled && isSharingMercuryFeatureEnabled.value && !this.socket) {
       return this.spark.mercury.socket.send(data);
     }

--- a/packages/plugin-board/src/realtime.js
+++ b/packages/plugin-board/src/realtime.js
@@ -145,6 +145,15 @@ const RealtimeService = Mercury.extend({
       .then((res) => {
         this.boardBindings = [res.binding];
         this.boardWebSocketUrl = res.webSocketUrl;
+
+        if (!res.sharedWebSocket) {
+          return this.connect()
+            .then(() => {
+              this.isSharingMercury = false;
+              return res;
+            });
+        }
+
         this.isSharingMercury = true;
         return res;
       });

--- a/packages/plugin-board/src/realtime.js
+++ b/packages/plugin-board/src/realtime.js
@@ -91,7 +91,6 @@ const RealtimeService = Mercury.extend({
     }
 
     // use mercury socket if it is shared
-    // if this.socket is defined then use it instead
     return this.spark.feature.getFeature(`developer`, `web-shared-mercury`)
       .then((isSharingMercuryFeatureEnabled) => {
         if (isSharingMercuryFeatureEnabled && this.isSharingMercury) {

--- a/packages/plugin-board/src/realtime.js
+++ b/packages/plugin-board/src/realtime.js
@@ -166,6 +166,10 @@ const RealtimeService = Mercury.extend({
    * @returns {Promise<Board~Registration>}
    */
   disconnectFromSharedMercury(channel) {
+    if (!this.isSharingMercury && this.socket && this.connected) {
+      return this.disconnect();
+    }
+
     return this.spark.board.unregisterFromSharedMercury(channel, this.boardBindings[0])
       .then((res) => {
         this.boardBindings = [];

--- a/packages/plugin-board/test/integration/spec/realtime.js
+++ b/packages/plugin-board/test/integration/spec/realtime.js
@@ -13,14 +13,8 @@ import fh from '@ciscospark/test-helper-file';
 import {map} from 'lodash';
 import uuid from 'uuid';
 
-function boardChannelToMercuryBinding(channelId) {
-  // make channelId mercury compatible replace `-` with `.` and `_` with `#`
-  return channelId.replace(/-/g, `.`).replace(/_/g, `#`);
-}
-
 describe(`plugin-board`, () => {
   describe(`realtime`, () => {
-    const mercuryBindingsPrefix = `board.`;
     let board, conversation, fixture, participants;
 
     before(`create users`, () => testUsers.create({count: 2})
@@ -53,19 +47,8 @@ describe(`plugin-board`, () => {
       }));
 
     before(`connect to realtime channel`, () => {
-      const mercuryBindingId = boardChannelToMercuryBinding(board.channelId);
-      const bindingStr = [mercuryBindingsPrefix + mercuryBindingId];
-      const bindingObj = {bindings: bindingStr};
-
       return Promise.all(map(participants, (participant) => {
-        return participant.spark.board.register(bindingObj)
-          .then((url) => {
-            participant.spark.board.realtime.set({
-              boardWebSocketUrl: url.webSocketUrl,
-              boardBindings: bindingStr
-            });
-            return participant.spark.board.realtime.connect();
-          });
+        return participant.spark.board.realtime.connectByOpenNewMercuryConnection(board);
       }));
     });
 

--- a/packages/plugin-board/test/integration/spec/sharing-mercury.js
+++ b/packages/plugin-board/test/integration/spec/sharing-mercury.js
@@ -126,7 +126,7 @@ describe(`plugin-board`, () => {
 
           // confirm that both are connected.
           assert.isTrue(participants[0].spark.board.realtime.isSharingMercury, `participant 0 is sharing mercury connection`);
-          assert.isTrue(participants[1].spark.mercury.connected, `participant 1 is connected`);
+          assert.isTrue(participants[0].spark.mercury.connected, `participant 0 is connected`);
           assert.isFalse(participants[1].spark.board.realtime.isSharingMercury, `participant 1 does not share mercury connection`);
           assert.isTrue(participants[1].spark.mercury.connected, `participant 1 is connected`);
 

--- a/packages/plugin-board/test/integration/spec/sharing-mercury.js
+++ b/packages/plugin-board/test/integration/spec/sharing-mercury.js
@@ -1,0 +1,134 @@
+/**!
+ *
+ * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import '../..';
+
+import {assert} from '@ciscospark/test-helper-chai';
+import CiscoSpark from '@ciscospark/spark-core';
+import testUsers from '@ciscospark/test-helper-test-users';
+import {map} from 'lodash';
+import uuid from 'uuid';
+
+describe(`plugin-board`, () => {
+  describe(`realtime - sharing mercury`, () => {
+    let board, conversation, participants;
+
+    before(`create users`, () => testUsers.create({count: 2})
+      .then((users) => {
+        participants = users;
+
+        return Promise.all(map(participants, (participant) => {
+          participant.spark = new CiscoSpark({
+            credentials: {
+              authorization: participant.token
+            }
+          });
+          return participant.spark.device.register()
+            .then(() => participant.spark.feature.setFeature(`developer`, `web-sharable-mercury`, true));
+        }));
+      }));
+
+    before(`create conversation`, () => participants[0].spark.conversation.create({
+      displayName: `Test Board Mercury`,
+      participants
+    })
+      .then((c) => {
+        conversation = c;
+        return conversation;
+      }));
+
+    before(`create channel (board)`, () => participants[0].spark.board.createChannel(conversation)
+      .then((channel) => {
+        board = channel;
+        return channel;
+      }));
+
+    beforeEach(`connect to mercury channel`, () => {
+      return Promise.all(map(participants, (participant) => {
+        return participant.spark.mercury.connect();
+      }));
+    });
+
+    // disconnect realtime
+    afterEach(`disconnect mercury`, () => Promise.all(map(participants, (participant) => {
+      return participant.spark.mercury.disconnect();
+    })));
+
+    describe(`#connectToSharedMercury`, () => {
+      it(`registers to share mercury connection`, () => {
+        return participants[0].spark.board.realtime.connectToSharedMercury(board)
+          .then((res) => {
+            assert.property(res, `action`);
+            assert.property(res, `binding`);
+            assert.property(res, `webSocketUrl`);
+            assert.property(res, `sharedWebSocket`);
+            assert.property(res, `mercuryConnectionServiceClusterUrl`);
+            assert.equal(res.action, `REPLACE`);
+            assert.deepEqual(res.mercuryConnectionServiceClusterUrl, participants[0].spark.mercury.localClusterServiceUrls.mercuryConnectionServiceClusterUrl);
+          });
+      });
+    });
+
+    describe(`#disconnectFromSharedMercury`, () => {
+      it(`removes board binding from registration`, () => {
+        return participants[0].spark.board.realtime.disconnectFromSharedMercury(board)
+          .then((res) => {
+            assert.property(res, `action`);
+            assert.property(res, `binding`);
+            assert.property(res, `webSocketUrl`);
+            assert.property(res, `sharedWebSocket`);
+            assert.equal(res.action, `REMOVE`);
+          });
+      });
+    });
+
+    describe(`#publish()`, () => {
+      describe(`string payload`, () => {
+        let uniqueRealtimeData;
+
+        before(() => {
+          uniqueRealtimeData = uuid.v4();
+          return Promise.all(map(participants, (participant) => {
+            return participant.spark.board.realtime.connectToSharedMercury(board);
+          }));
+        });
+
+        after(() => {
+          return Promise.all(map(participants, (participant) => {
+            return participant.spark.board.realtime.disconnectFromSharedMercury(board);
+          }));
+        });
+
+        it(`posts a message to the specified board`, (done) => {
+          const data = {
+            envelope: {
+              channelId: board,
+              roomId: conversation.id
+            },
+            payload: {
+              msg: uniqueRealtimeData
+            }
+          };
+
+          // participan 1 is going to listen for RT data and confirm that we
+          // have the same data that was sent.
+          participants[1].spark.mercury.once(`event:board.activity`, ({data}) => {
+            assert.equal(data.contentType, `STRING`);
+            assert.equal(data.payload.msg, uniqueRealtimeData);
+            done();
+          });
+
+          // confirm that both are connected.
+          assert.isTrue(participants[0].spark.mercury.connected, `participant 0 is connected`);
+          assert.isTrue(participants[1].spark.mercury.connected, `participant 1 is connected`);
+
+          // do not return promise because we want done() to be called on
+          // board.activity
+          participants[0].spark.board.realtime.publish(board, data);
+        });
+      });
+    });
+  });
+});

--- a/packages/plugin-board/test/integration/spec/sharing-mercury.js
+++ b/packages/plugin-board/test/integration/spec/sharing-mercury.js
@@ -26,7 +26,7 @@ describe(`plugin-board`, () => {
             }
           });
           return participant.spark.device.register()
-            .then(() => participant.spark.feature.setFeature(`developer`, `web-sharable-mercury`, true));
+            .then(() => participant.spark.feature.setFeature(`developer`, `web-shared-mercury`, true));
         }));
       }));
 

--- a/packages/plugin-board/test/unit/spec/board.js
+++ b/packages/plugin-board/test/unit/spec/board.js
@@ -566,12 +566,12 @@ describe(`plugin-board`, () => {
 
     it(`rejects when localClusterServiceUrls is null`, () => {
       spark.mercury.localClusterServiceUrls = null;
-      assert.isRejected(spark.board.registerToShareMercury(channel));
+      return assert.isRejected(spark.board.registerToShareMercury(channel));
     });
 
     it(`rejects when web-shared-mercury is not enabled`, () => {
       spark.feature.getFeature.returns(Promise.resolve(false));
-      assert.isRejected(spark.board.registerToShareMercury(channel));
+      return assert.isRejected(spark.board.registerToShareMercury(channel));
     });
   });
 });

--- a/packages/plugin-board/test/unit/spec/board.js
+++ b/packages/plugin-board/test/unit/spec/board.js
@@ -553,8 +553,7 @@ describe(`plugin-board`, () => {
         .then(() => {
           assert.calledWith(spark.request, sinon.match({
             method: `POST`,
-            api: `board`,
-            resource: `/channels/${channel.channelId}/register`,
+            uri: `${channel.channelUrl}/register`,
             body: {
               mercuryConnectionServiceClusterUrl: spark.mercury.localClusterServiceUrls.mercuryConnectionServiceClusterUrl,
               webSocketUrl: spark.device.webSocketUrl,

--- a/packages/plugin-board/test/unit/spec/board.js
+++ b/packages/plugin-board/test/unit/spec/board.js
@@ -536,4 +536,42 @@ describe(`plugin-board`, () => {
       }));
     });
   });
+
+  describe(`#registerToShareMercury()`, () => {
+
+    beforeEach(() => {
+      spark.request.reset();
+      spark.mercury.localClusterServiceUrls = {
+        mercuryApiServiceClusterUrl: `https://mercury-api-a5.wbx2.com/v1`,
+        mercuryConnectionServiceClusterUrl: `https://mercury-connection-a5.wbx2.com/v1`
+      };
+      spark.feature.getFeature.returns(Promise.resolve(true));
+    });
+
+    it(`requests POST data to registration service`, () => {
+      return spark.board.registerToShareMercury(channel)
+        .then(() => {
+          assert.calledWith(spark.request, sinon.match({
+            method: `POST`,
+            api: `board`,
+            resource: `/channels/${channel.channelId}/register`,
+            body: {
+              mercuryConnectionServiceClusterUrl: spark.mercury.localClusterServiceUrls.mercuryConnectionServiceClusterUrl,
+              webSocketUrl: spark.device.webSocketUrl,
+              action: `REPLACE`
+            }
+          }));
+        });
+    });
+
+    it(`rejects when localClusterServiceUrls is null`, () => {
+      spark.mercury.localClusterServiceUrls = null;
+      assert.isRejected(spark.board.registerToShareMercury(channel));
+    });
+
+    it(`rejects when web-shared-mercury is not enabled`, () => {
+      spark.feature.getFeature.returns(Promise.resolve(false));
+      assert.isRejected(spark.board.registerToShareMercury(channel));
+    });
+  });
 });

--- a/packages/plugin-board/test/unit/spec/realtime.js
+++ b/packages/plugin-board/test/unit/spec/realtime.js
@@ -130,6 +130,20 @@ describe(`plugin-board`, () => {
       });
     });
 
+    describe(`#_boardChannelIdToMercuryBinding`, () => {
+      it(`adds .board binding prefix`, () => {
+        assert.equal(spark.board.realtime._boardChannelIdToMercuryBinding(`test`), `board.test`);
+      });
+
+      it(`replaces '-' with '.' and '_' with '#'`, () => {
+        assert.equal(spark.board.realtime._boardChannelIdToMercuryBinding(`abc-1234_bcd`), `board.abc.1234#bcd`);
+      });
+
+      it(`leaves strings without - and _ alone`, () => {
+        assert.equal(spark.board.realtime._boardChannelIdToMercuryBinding(`abcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()+=`), `board.abcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()+=`);
+      });
+    });
+
     describe(`#_attemptConnection()`, () => {
 
       before(() => {

--- a/packages/plugin-board/test/unit/spec/realtime.js
+++ b/packages/plugin-board/test/unit/spec/realtime.js
@@ -131,7 +131,7 @@ describe(`plugin-board`, () => {
     });
 
     describe(`#_boardChannelIdToMercuryBinding`, () => {
-      it(`adds .board binding prefix`, () => {
+      it(`adds board. binding prefix`, () => {
         assert.equal(spark.board.realtime._boardChannelIdToMercuryBinding(`test`), `board.test`);
       });
 

--- a/packages/plugin-mercury/package.json
+++ b/packages/plugin-mercury/package.json
@@ -11,6 +11,7 @@
     "@ciscospark/common": "^0.7.52",
     "@ciscospark/http-core": "^0.7.53",
     "@ciscospark/plugin-wdm": "^0.7.67",
+    "@ciscospark/plugin-feature": "^0.7.67",
     "@ciscospark/spark-core": "^0.7.55",
     "babel-runtime": "^6.3.19",
     "backoff": "^2.5.0",

--- a/packages/plugin-mercury/src/index.js
+++ b/packages/plugin-mercury/src/index.js
@@ -4,6 +4,7 @@
  */
 
 import '@ciscospark/plugin-wdm';
+import '@ciscospark/plugin-feature';
 
 import {registerPlugin} from '@ciscospark/spark-core';
 import Mercury from './mercury';

--- a/packages/plugin-mercury/src/mercury.js
+++ b/packages/plugin-mercury/src/mercury.js
@@ -113,12 +113,14 @@ const Mercury = SparkPlugin.extend({
 
     let webSocketUrl = this.spark.device.webSocketUrl;
 
-    const isSharingMercuryFeatureEnabled = this.spark.device.features.developer.get(`web-shared-mercury`);
-    if (isSharingMercuryFeatureEnabled && isSharingMercuryFeatureEnabled.value) {
-      webSocketUrl += `${webSocketUrl.includes(`?`) ? `&` : `?`}mercuryRegistrationStatus=true&isRegistrationRefreshEnabled=true`;
-    }
+    this.spark.feature.getFeature(`developer`, `web-shared-mercury`)
+      .then((isSharingMercuryFeatureEnabled) => {
+        if (isSharingMercuryFeatureEnabled) {
+          webSocketUrl += `${webSocketUrl.includes(`?`) ? `&` : `?`}mercuryRegistrationStatus=true&isRegistrationRefreshEnabled=true`;
+        }
 
-    this.spark.credentials.getAuthorization()
+        return this.spark.credentials.getAuthorization();
+      })
       .then((authorization) => socket.open(webSocketUrl, {
         forceCloseDelay: this.config.forceCloseDelay,
         pingInterval: this.config.pingInterval,

--- a/packages/plugin-mercury/src/mercury.js
+++ b/packages/plugin-mercury/src/mercury.js
@@ -113,7 +113,7 @@ const Mercury = SparkPlugin.extend({
 
     let webSocketUrl = this.spark.device.webSocketUrl;
 
-    const isSharingMercuryFeatureEnabled = this.spark.device.features.developer.get(`web-sharable-mercury`);
+    const isSharingMercuryFeatureEnabled = this.spark.device.features.developer.get(`web-shared-mercury`);
     if (isSharingMercuryFeatureEnabled && isSharingMercuryFeatureEnabled.value) {
       webSocketUrl += `${webSocketUrl.includes(`?`) ? `&` : `?`}mercuryRegistrationStatus=true&isRegistrationRefreshEnabled=true`;
     }

--- a/packages/plugin-mercury/src/socket/socket-base.js
+++ b/packages/plugin-mercury/src/socket/socket-base.js
@@ -342,7 +342,7 @@ export default class Socket extends EventEmitter {
       });
 
       const waitForBufferState = (event) => {
-        if (!event.data.type && event.data.data.eventType === `mercury.buffer_state`) {
+        if (!event.data.type && (event.data.data.eventType === `mercury.buffer_state` || event.data.data.eventType === `mercury.registration_status`)) {
           this.removeListener(`message`, waitForBufferState);
           this._ping();
           resolve();

--- a/packages/plugin-mercury/src/socket/socket-base.js
+++ b/packages/plugin-mercury/src/socket/socket-base.js
@@ -187,7 +187,7 @@ export default class Socket extends EventEmitter {
 
       // always add buffer_states query param
       /* istanbul ignore else */
-      if (!url.includes(`bufferStates`)) {
+      if (!url.includes(`bufferStates`) && !url.includes(`mercuryRegistrationStatus`)) {
         url += `${url.includes(`?`) ? `&` : `?`}bufferStates=true`;
       }
 

--- a/packages/plugin-mercury/test/integration/spec/sharable-mercury.js
+++ b/packages/plugin-mercury/test/integration/spec/sharable-mercury.js
@@ -23,7 +23,7 @@ describe(`plugin-mercury`, function() {
           }
         });
         return spark.device.register()
-          .then(() => spark.feature.setFeature(`developer`, `web-sharable-mercury`, true));
+          .then(() => spark.feature.setFeature(`developer`, `web-shared-mercury`, true));
       }));
 
     afterEach(() => spark && spark.mercury.disconnect());

--- a/packages/plugin-mercury/test/integration/spec/sharable-mercury.js
+++ b/packages/plugin-mercury/test/integration/spec/sharable-mercury.js
@@ -1,0 +1,52 @@
+/**!
+ *
+ * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import '../..';
+
+import {assert} from '@ciscospark/test-helper-chai';
+import sinon from '@ciscospark/test-helper-sinon';
+import CiscoSpark from '@ciscospark/spark-core';
+import testUsers from '@ciscospark/test-helper-test-users';
+
+describe(`plugin-mercury`, function() {
+  this.timeout(30000);
+  describe(`Sharable Mercury`, () => {
+    let spark;
+
+    beforeEach(() => testUsers.create({count: 1})
+      .then((users) => {
+        spark = new CiscoSpark({
+          credentials: {
+            authorization: users[0].token
+          }
+        });
+        return spark.device.register()
+          .then(() => spark.feature.setFeature(`developer`, `web-sharable-mercury`, true));
+      }));
+
+    afterEach(() => spark && spark.mercury.disconnect());
+
+    describe(`#connect()`, () => {
+      it(`connects to mercury`, () => assert.isFulfilled(spark.mercury.connect()));
+    });
+
+    it(`emits messages that arrive before authorization completes`, () => {
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      spark.mercury.on(`event:mercury.buffer_state`, spy1);
+      spark.mercury.on(`event:mercury.registration_status`, spy2);
+      return spark.mercury.connect()
+        .then(() => {
+          assert.notCalled(spy1);
+          assert.calledOnce(spy2);
+          const data = spy2.args[0][0].data;
+          assert.property(data, `bufferState`);
+          assert.property(data, `localClusterServiceUrls`);
+
+          assert.deepEqual(spark.mercury.localClusterServiceUrls, data.localClusterServiceUrls);
+        });
+    });
+  });
+});

--- a/packages/plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/plugin-mercury/test/unit/spec/mercury.js
@@ -117,6 +117,24 @@ describe(`plugin-mercury`, () => {
           });
       });
 
+      describe(`when web-sharable-socket feature is enabled`, () => {
+        beforeEach(() => {
+          spark.device.features.developer.get.returns({value: true});
+        });
+
+        afterEach(() => {
+          spark.device.features.developer.get = sinon.stub();
+        });
+
+        it(`sets mercuryRegistrationStatus=true to web socket url`, () => {
+          return mercury.connect()
+            .then(() => {
+              assert.calledWith(Socket.prototype.open, sinon.match(/mercuryRegistrationStatus=true/), sinon.match.any);
+              assert.calledWith(Socket.prototype.open, sinon.match(/isRegistrationRefreshEnabled=true/), sinon.match.any);
+            });
+        });
+      });
+
       describe(`when \`maxRetries\` is set`, () => {
         // skipping due to apparent bug with lolex in all browsers but Chrome.
         skipInBrowser(it)(`fails after \`maxRetries\` attempts`, () => {

--- a/packages/plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/plugin-mercury/test/unit/spec/mercury.js
@@ -119,11 +119,7 @@ describe(`plugin-mercury`, () => {
 
       describe(`when web-sharable-socket feature is enabled`, () => {
         beforeEach(() => {
-          spark.device.features.developer.get.returns({value: true});
-        });
-
-        afterEach(() => {
-          spark.device.features.developer.get = sinon.stub();
+          spark.feature.getFeature.returns(Promise.resolve(true));
         });
 
         it(`sets mercuryRegistrationStatus=true to web socket url`, () => {
@@ -145,16 +141,16 @@ describe(`plugin-mercury`, () => {
           assert.notCalled(Socket.prototype.open);
 
           const promise = mercury.connect();
-          return promiseTick(3)
+          return promiseTick(4)
             .then(() => {
               assert.calledOnce(Socket.prototype.open);
               clock.tick(mercury.config.backoffTimeReset);
-              return promiseTick(3);
+              return promiseTick(4);
             })
             .then(() => {
               assert.calledTwice(Socket.prototype.open);
               clock.tick(2 * mercury.config.backoffTimeReset);
-              return promiseTick(3);
+              return promiseTick(4);
             })
             .then(() => {
               assert.calledThrice(Socket.prototype.open);
@@ -192,16 +188,16 @@ describe(`plugin-mercury`, () => {
           assert.notCalled(Socket.prototype.open);
 
           const promise = mercury.connect();
-          return promiseTick(3)
+          return promiseTick(4)
             .then(() => {
               assert.calledOnce(Socket.prototype.open);
               clock.tick(mercury.config.backoffTimeReset);
-              return promiseTick(3);
+              return promiseTick(4);
             })
             .then(() => {
               assert.calledTwice(Socket.prototype.open);
               clock.tick(2 * mercury.config.backoffTimeReset);
-              return promiseTick(3);
+              return promiseTick(4);
             })
             .then(() => {
               assert.calledThrice(Socket.prototype.open);
@@ -211,7 +207,7 @@ describe(`plugin-mercury`, () => {
             .then(() => {
               assert.calledThrice(Socket.prototype.open);
               clock.tick(8 * mercury.config.backoffTimeReset);
-              return promiseTick(3);
+              return promiseTick(4);
             })
             .then(() => {
               assert.calledThrice(Socket.prototype.open);
@@ -226,7 +222,7 @@ describe(`plugin-mercury`, () => {
             socketOpenStub.onCall(0).returns(Promise.reject(new AuthorizationError()));
             assert.notCalled(spark.refresh);
             const promise = mercury.connect();
-            return promiseTick(4)
+            return promiseTick(5)
               .then(() => {
                 assert.called(spark.refresh);
                 clock.tick(1000);
@@ -250,10 +246,10 @@ describe(`plugin-mercury`, () => {
           // skipping due to apparent bug with lolex in all browsers but Chrome.
         skipInBrowser(it)(`does not continue attempting to connect`, () => {
           mercury.connect();
-          return promiseTick(1)
+          return promiseTick(2)
             .then(() => {
               clock.tick(6 * spark.mercury.config.backoffTimeReset);
-              return promiseTick(1);
+              return promiseTick(2);
             })
             .then(() => {
               assert.calledOnce(Socket.prototype.open);

--- a/packages/plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/plugin-mercury/test/unit/spec/mercury.js
@@ -117,7 +117,7 @@ describe(`plugin-mercury`, () => {
           });
       });
 
-      describe(`when web-sharable-socket feature is enabled`, () => {
+      describe(`when web-shared-socket feature is enabled`, () => {
         beforeEach(() => {
           spark.feature.getFeature.returns(Promise.resolve(true));
         });

--- a/packages/plugin-mercury/test/unit/spec/socket.js
+++ b/packages/plugin-mercury/test/unit/spec/socket.js
@@ -322,6 +322,22 @@ describe(`plugin-mercury`, () => {
           return assert.isFulfilled(promise)
             .then(() => s.close());
         });
+
+        it(`resolves upon receiving registration status`, () => {
+          const s = new Socket();
+          const promise = s.open(`ws://example.com`, mockoptions);
+          mockWebSocket.readyState = 1;
+          mockWebSocket.emit(`open`);
+          mockWebSocket.emit(`message`, {
+            data: JSON.stringify({
+              data: {
+                eventType: `mercury.registration_status`
+              }
+            })
+          });
+          return assert.isFulfilled(promise)
+            .then(() => s.close());
+        });
       });
     });
 

--- a/packages/plugin-mercury/test/unit/spec/socket.js
+++ b/packages/plugin-mercury/test/unit/spec/socket.js
@@ -197,14 +197,24 @@ describe(`plugin-mercury`, () => {
         assert.match(s.url, /outboundWireFormat=text/);
         assert.equal(s.url, `ws://example.com?outboundWireFormat=text&bufferStates=true`);
         const p1 = s.close();
+
         s = new Socket();
         s.open(`ws://example.com?queryparam=something`, mockoptions);
         assert.match(s.url, /outboundWireFormat=text/);
         assert.equal(s.url, `ws://example.com?queryparam=something&outboundWireFormat=text&bufferStates=true`);
+
         return Promise.all([
           p1,
           s.close()
         ]);
+      });
+
+      it(`doesn't set bufferStates if mercuryRegistrationStatus is already set`, () => {
+        const s = new Socket();
+        s.open(`ws://example.com?mercuryRegistrationStatus=true`, mockoptions);
+        assert.notMatch(s.url, /bufferStates/);
+        assert.equal(s.url, `ws://example.com?mercuryRegistrationStatus=true&outboundWireFormat=text`);
+        return s.close();
       });
 
       it(`sets the underlying socket\'s binary type`, () => assert.equal(socket.binaryType, `arraybuffer`));

--- a/packages/test-helper-mock-spark/src/index.js
+++ b/packages/test-helper-mock-spark/src/index.js
@@ -147,6 +147,10 @@ function makeSpark(options) {
       registered: true,
       register: sinon.stub().returns(Promise.resolve())
     },
+    feature: {
+      setFeature: sinon.stub().returns(Promise.resolve(false)),
+      getFeature: sinon.stub().returns(Promise.resolve(false))
+    },
     encryption: {},
     metrics: {
       sendUnstructured: sinon.spy()

--- a/src/client/mercury/mercury.js
+++ b/src/client/mercury/mercury.js
@@ -180,7 +180,7 @@ var Mercury = SparkBase.extend(
 
     var socketUrl = this.spark.device.webSocketUrl;
 
-    if (this.spark.feature.getFeature('developer', 'web-sharable-mercury')) {
+    if (this.spark.feature.getFeature('developer', 'web-shared-mercury')) {
       socketUrl = socket._addQueryParameter('mercuryRegistrationStatus=true', socketUrl);
       socketUrl = socket._addQueryParameter('isRegistrationRefreshEnabled=true', socketUrl);
     }

--- a/src/client/mercury/socket/socket-base.js
+++ b/src/client/mercury/socket/socket-base.js
@@ -163,19 +163,7 @@ assign(Socket.prototype, {
 
       options = options || {};
 
-      // It's unlikely we'll ever not need to add the extra parameter here.
-      /* istanbul ignore else */
-      if (url.indexOf('outboundWireFormat=text') === -1) {
-        url += ((url.indexOf('?') === -1) ? '?' : '&') + 'outboundWireFormat=text';
-      }
-
-      /* istanbul ignore else */
-      if (url.indexOf('bufferStates=true') === -1) {
-        // It's unlikely bufferStates is the first parameter as
-        // outboundingWireFormat will be there first
-        /* istanbul ignore next */
-        url += ((url.indexOf('?') === -1) ? '?' : '&') + 'bufferStates=true';
-      }
+      url = this._addQueryParametersToUrl(url);
 
       this.logger.info('socket: connecting to websocket');
       this._socket = this._open(url);
@@ -271,6 +259,28 @@ assign(Socket.prototype, {
       this._socket.send(data);
       resolve();
     }.bind(this));
+  },
+
+  _addQueryParametersToUrl: function _addQueryParametersToUrl(socketUrl) {
+    socketUrl = this._addQueryParameter('outboundWireFormat=text', socketUrl);
+
+    // It should have only one of mercuryRegistrationStatus or bufferStates
+    // note: when shared socket is stable, we won't use bufferStates anymore
+    /* istanbul ignore else */
+    if (socketUrl.indexOf('mercuryRegistrationStatus=true') === -1) {
+      socketUrl = this._addQueryParameter('bufferStates=true', socketUrl);
+    }
+
+    return socketUrl;
+  },
+
+  _addQueryParameter: function _addQueryParameter(queryParam, url) {
+    /* istanbul ignore else */
+    if (url.indexOf(queryParam) === -1) {
+      url += ((url.indexOf('?') === -1) ? '?' : '&') + queryParam;
+    }
+
+    return url;
   },
 
   _acknowledge: function _acknowledge(event) {

--- a/src/client/services/board/board.js
+++ b/src/client/services/board/board.js
@@ -241,8 +241,8 @@ var BoardService = SparkBase.extend({
    * Ensure board channelId is compatible with mercury bindings by replacing
    * '-' with '.' and '_' with '#'
    * @memberof Board.BoardService
-   * @param  {String} channel.channelId
-   * @returns {String} mercury-binding compatible string
+   * @param  {string} channelId channel.channelId
+   * @returns {string} mercury-binding compatible string
    */
   boardChannelIdToMercuryBinding: function boardChannelIdToMercuryBinding(channelId) {
     // make channelId mercury compatible replace '-' with '.' and '_' with '#'

--- a/src/client/services/board/board.js
+++ b/src/client/services/board/board.js
@@ -16,6 +16,8 @@ var Realtime = require('./realtime');
 var reduce = require('lodash.reduce');
 var SparkBase = require('../../../lib/spark-base');
 
+var MERCURY_BINDING_PREFIX = 'board.';
+
 /**
  * @class
  * @extends {SparkBase}
@@ -233,6 +235,18 @@ var BoardService = SparkBase.extend({
         message.payload = decryptedData;
         return message;
       });
+  },
+
+  /**
+   * Ensure board channelId is compatible with mercury bindings by replacing
+   * '-' with '.' and '_' with '#'
+   * @memberof Board.BoardService
+   * @param  {String} channel.channelId
+   * @return {String} mercury-binding compatible string
+   */
+  boardChannelIdToMercuryBinding: function boardChannelIdToMercuryBinding(channelId) {
+    // make channelId mercury compatible replace '-' with '.' and '_' with '#'
+    return MERCURY_BINDING_PREFIX + channelId.replace(/-/g, '.').replace(/_/g, '#');
   },
 
   /**

--- a/src/client/services/board/board.js
+++ b/src/client/services/board/board.js
@@ -242,7 +242,7 @@ var BoardService = SparkBase.extend({
    * '-' with '.' and '_' with '#'
    * @memberof Board.BoardService
    * @param  {String} channel.channelId
-   * @return {String} mercury-binding compatible string
+   * @returns {String} mercury-binding compatible string
    */
   boardChannelIdToMercuryBinding: function boardChannelIdToMercuryBinding(channelId) {
     // make channelId mercury compatible replace '-' with '.' and '_' with '#'

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -307,6 +307,12 @@ var PersistenceService = SparkBase.extend({
       });
   },
 
+  /**
+   * Registers with Mercury to share mercury connection
+   * @memberof Board.PersistenceService
+   * @param  {Board~Channel} channel
+   * @return {Promise<Board~Registration>}
+   */
   registerForSharingMercury: function registerForSharingMercury(channel) {
     if (!this.spark.mercury.localClusterServiceUrls) {
       return Promise.reject(new Error('`localClusterServiceUrls` is not defined, make sure mercury is connected'));

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -307,6 +307,34 @@ var PersistenceService = SparkBase.extend({
       });
   },
 
+  registerForSharingMercury: function registerForSharingMercury(channel) {
+    if (!this.spark.mercury.localClusterServiceUrls) {
+      return Promise.reject(new Error('`localClusterServiceUrls` is not defined, make sure mercury is connected'));
+    }
+    else if (!this.spark.feature.getFeature('developer', 'web-sharable-mercury')) {
+      return Promise.reject(new Error('`web-sharable-mercury` is not enabled'));
+    }
+
+    var webSocketUrl = this.spark.device.webSocketUrl;
+    var localClusterServiceUrls = this.spark.mercury.localClusterServiceUrls;
+
+    var data = {
+      mercuryConnectionServiceClusterUrl: localClusterServiceUrls.mercuryConnectionServiceClusterUrl,
+      webSocketUrl: webSocketUrl,
+      action: 'REPLACE'
+    };
+
+    return this.spark.request({
+      method: 'POST',
+      api: 'board',
+      resource: '/channels/' + channel.channelId + '/register',
+      body: data
+    })
+      .then(function resolveWithBody(res) {
+        return res.body;
+      });
+  },
+
   _addContentChunk: function _addContentHelper(channel, contentChunk) {
     return this.spark.board.encryptContents(channel.defaultEncryptionKeyUrl, contentChunk)
       .then(function addContent(res) {

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -332,8 +332,7 @@ var PersistenceService = SparkBase.extend({
 
     return this.spark.request({
       method: 'POST',
-      api: 'board',
-      resource: '/channels/' + channel.channelId + '/register',
+      uri: channel.channelUrl + '/register',
       body: data
     })
       .then(function resolveWithBody(res) {
@@ -358,8 +357,7 @@ var PersistenceService = SparkBase.extend({
 
     return this.spark.request({
       method: 'POST',
-      api: 'board',
-      resource: '/channels/' + channel.channelId + '/register',
+      uri: channel.channelUrl + '/register',
       body: data
     })
       .then(function resolveWithBody(res) {

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -317,8 +317,8 @@ var PersistenceService = SparkBase.extend({
     if (!this.spark.mercury.localClusterServiceUrls) {
       return Promise.reject(new Error('`localClusterServiceUrls` is not defined, make sure mercury is connected'));
     }
-    else if (!this.spark.feature.getFeature('developer', 'web-sharable-mercury')) {
-      return Promise.reject(new Error('`web-sharable-mercury` is not enabled'));
+    else if (!this.spark.feature.getFeature('developer', 'web-shared-mercury')) {
+      return Promise.reject(new Error('`web-shared-mercury` is not enabled'));
     }
 
     var webSocketUrl = this.spark.device.webSocketUrl;

--- a/src/client/services/board/persistence/persistence.js
+++ b/src/client/services/board/persistence/persistence.js
@@ -313,7 +313,7 @@ var PersistenceService = SparkBase.extend({
    * @param  {Board~Channel} channel
    * @return {Promise<Board~Registration>}
    */
-  registerForSharingMercury: function registerForSharingMercury(channel) {
+  registerToShareMercury: function registerToShareMercury(channel) {
     if (!this.spark.mercury.localClusterServiceUrls) {
       return Promise.reject(new Error('`localClusterServiceUrls` is not defined, make sure mercury is connected'));
     }
@@ -328,6 +328,32 @@ var PersistenceService = SparkBase.extend({
       mercuryConnectionServiceClusterUrl: localClusterServiceUrls.mercuryConnectionServiceClusterUrl,
       webSocketUrl: webSocketUrl,
       action: 'REPLACE'
+    };
+
+    return this.spark.request({
+      method: 'POST',
+      api: 'board',
+      resource: '/channels/' + channel.channelId + '/register',
+      body: data
+    })
+      .then(function resolveWithBody(res) {
+        return res.body;
+      });
+  },
+
+  /**
+   * Unregister the board from share mercury connection
+   * @memberof Board.PersistenceService
+   * @param  {Board~Channel} channel
+   * @param  {Object} binding - board binding
+   * @return {Promise<Board~Registration>}
+   */
+  unregisterFromSharedMercury: function unregisterFromSharedMercury(channel, binding) {
+    var webSocketUrl = this.spark.device.webSocketUrl;
+    var data = {
+      binding: binding,
+      webSocketUrl: webSocketUrl,
+      action: 'REMOVE'
     };
 
     return this.spark.request({

--- a/src/client/services/board/realtime/realtime.js
+++ b/src/client/services/board/realtime/realtime.js
@@ -165,6 +165,11 @@ var RealtimeService = Mercury.extend({
     * @returns {Promise<Board~Registration>}
     */
   disconnectFromSharedMercury: function disconnectFromSharedMercury(channel) {
+    // this means a second socket was created instead of being shared
+    if (!this.isSharingMercury && this.socket && this.connected) {
+      return this.disconnect();
+    }
+
     return this.spark.board.persistence.unregisterFromSharedMercury(channel, this.boardBindings[0])
       .then(function assignBindingAndWebSocketUrl(res) {
         this.boardBindings = [];

--- a/src/client/services/board/realtime/realtime.js
+++ b/src/client/services/board/realtime/realtime.js
@@ -144,6 +144,15 @@ var RealtimeService = Mercury.extend({
       .then(function assignBindingAndWebSocketUrl(res) {
         this.boardBindings = [res.binding];
         this.boardWebSocketUrl = res.webSocketUrl;
+
+        if (!res.sharedWebSocket) {
+          return this.connect()
+            .then(function returnRegistrationInfo() {
+              this.isSharingMercury = false;
+              return res;
+            }.bind(this));
+        }
+
         this.isSharingMercury = true;
         return res;
       }.bind(this));

--- a/src/client/services/board/realtime/realtime.js
+++ b/src/client/services/board/realtime/realtime.js
@@ -100,7 +100,7 @@ var RealtimeService = Mercury.extend({
     // board's instance
     // however, if board.socket is defined, we're falling back to separate
     // socket
-    if (this.spark.feature.getFeature('developer', 'web-sharable-mercury') && !this.socket) {
+    if (this.spark.feature.getFeature('developer', 'web-shared-mercury') && !this.socket) {
       return this.spark.mercury.socket.send(data);
     }
     else {

--- a/src/client/services/board/realtime/realtime.js
+++ b/src/client/services/board/realtime/realtime.js
@@ -108,8 +108,14 @@ var RealtimeService = Mercury.extend({
     }
   },
 
+  /**
+    * Connect to an existing sharable mercury connection
+    * @memberof Board.RealtimeService
+    * @param   {Board~Channel} channel
+    * @returns {Promise<Board~Registration>}
+    */
   connectToSharedMercury: function connectToSharedMercury(channel) {
-    return this.spark.board.persistence.registerForSharingMercury(channel)
+    return this.spark.board.persistence.registerToShareMercury(channel)
       .then(function assignBindingAndWebSocketUrl(res) {
         this.boardBindings = [res.binding];
         this.boardWebSocketUrl = res.webSocketUrl;
@@ -117,23 +123,19 @@ var RealtimeService = Mercury.extend({
       }.bind(this));
   },
 
+  /**
+    * Remove binding and stop receiving messages from mercury
+    * @memberof Board.RealtimeService
+    * @param   {Board~Channel} channel
+    * @returns {Promise<Board~Registration>}
+    */
   disconnectFromSharedMercury: function disconnectFromSharedMercury(channel) {
-    var webSocketUrl = this.spark.device.webSocketUrl;
-    var data = {
-      binding: this.spark.board.realtime.boardBindings[0],
-      webSocketUrl: webSocketUrl,
-      action: 'REMOVE'
-    };
-
-    return this.spark.request({
-      method: 'POST',
-      api: 'board',
-      resource: '/channels/' + channel.channelId + '/register',
-      body: data
-    })
-      .then(function resolveWithBody(res) {
-        return res.body;
-      });
+    return this.spark.board.persistence.unregisterFromSharedMercury(channel, this.boardBindings[0])
+      .then(function assignBindingAndWebSocketUrl(res) {
+        this.boardBindings = [];
+        this.boardWebSocketUrl = '';
+        return res;
+      }.bind(this));
   },
 
   _attemptConnection: function _attemptConnection() {

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -38,30 +38,14 @@ describe('Services', function() {
 
     var board;
     var conversation;
-    var mercuryBindingsPrefix = 'board.';
 
     function ensureBoardMercury() {
       // register with mercury binding and connect to mercury socket for users spark and mccoy
       console.log('connecting to board mercury');
-      var mercuryBindingId = boardChannelToMercuryBinding(board.channelId);
-      var bindingStr = [mercuryBindingsPrefix + mercuryBindingId];
-
-      var bindingObj =  {
-        bindings: bindingStr
-      };
-
       return Promise.all(map(party, function(shouldCreateClient, name) {
-        return party[name].spark.board.persistence.register(bindingObj)
-          .then(function setWebSocketUrl(url) {
-            if (url.webSocketUrl) {
-              party[name].spark.board.realtime.set({boardWebSocketUrl: url.webSocketUrl});
-              party[name].spark.board.realtime.set({boardBindings: bindingStr});
-              return Promise.resolve(party[name].spark.board.realtime.listening ||
-                  party[name].spark.board.realtime.listen())
-                .then(function() {
-                  console.log('finished connecting mercury for user: ', name);
-                });
-            }
+        return party[name].spark.board.realtime.connectByOpenNewMercuryConnection(board)
+          .then(function() {
+            console.log('finished connecting mercury for user: ', name);
           });
       }));
     }
@@ -122,11 +106,6 @@ describe('Services', function() {
         .catch(function(reason) {
           return Promise.reject(reason);
         });
-    }
-
-    function boardChannelToMercuryBinding(channelId) {
-      // make channelId mercury compatible replace '-' with '.' and '_' with '#'
-      return channelId.replace(/-/g, '.').replace(/_/g, '#');
     }
 
     before(function beamDown() {

--- a/test/integration/spec/services/board/sharable-mercury.js
+++ b/test/integration/spec/services/board/sharable-mercury.js
@@ -1,0 +1,183 @@
+/**!
+ *
+ * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
+ */
+
+'use strict';
+
+var assert = require('chai').assert;
+var uuid = require('uuid');
+var pluck = require('lodash.pluck');
+var map = require('lodash.map');
+var landingparty = require('../../../lib/landingparty');
+
+describe('Services', function() {
+  describe('Board', function() {
+    this.timeout(120000);
+
+    // added a third member in order to be able to create another room.
+    var party = {
+      spock: true,
+      mccoy: true,
+    };
+
+    var board;
+    var conversation;
+    var uniqueRealtimeData;
+
+    function ensureConversation() {
+      if (!conversation) {
+        console.log('creating new conversation for board ');
+        return party.spock.spark.conversation.create({
+          displayName: 'Test Board Mercury',
+          participants: pluck(party, 'id')
+        })
+        .then(function(c) {
+          console.log('created new conversation for board with id: ', c.id);
+          conversation = c;
+          return Promise.resolve(c);
+        })
+        .catch(function(reason) {
+          console.log('Error creating new conversation for board ', reason);
+          return Promise.reject(reason);
+        });
+      }
+      else {
+        return Promise.resolve(conversation);
+      }
+    }
+
+    before(function beamDown() {
+      return landingparty.beamDown(party)
+        .then(function() {
+          return party.spock.spark.feature.setFeature('developer', 'web-sharable-mercury', true);
+        })
+        .then(function() {
+          return party.mccoy.spark.feature.setFeature('developer', 'web-sharable-mercury', true);
+        });
+    });
+
+    before(function createBoard() {
+      return ensureConversation()
+        .then(function createBoard() {
+          var data = {
+            properties: {
+              darkTheme: false
+            }
+          };
+          console.log('Creating new board');
+          return party.spock.spark.board.persistence.createChannel(conversation, data)
+            .then(function(w) {
+              board = w;
+              console.log('created new board: ', board);
+              return board;
+            });
+        })
+        .catch(function(reason) {
+          return Promise.reject(reason);
+        });
+    });
+
+    // so that we can connect with new feature toggles
+    before(function disconnectFromNormalMercury() {
+      return Promise.all(map(party, function(member) {
+        return member.spark.mercury.disconnect();
+      }));
+    });
+
+    after(function cleanUpFeatureToggles() {
+      return party.spock.spark.feature.setFeature('developer', 'web-sharable-mercury', false)
+        .then(function() {
+          return party.mccoy.spark.feature.setFeature('developer', 'web-sharable-mercury', false);
+        });
+    });
+
+    describe('Sharing Mercury', function() {
+      describe('Mercury', function() {
+        it('connects to mercury and gets registration status', function(done) {
+          party.spock.spark.mercury.on('mercury.registration_status', function(event) {
+            assert.property(event, 'bufferState');
+            assert.property(event, 'localClusterServiceUrls');
+            assert.equal(party.spock.spark.mercury.localClusterServiceUrls, event.localClusterServiceUrls);
+            done();
+          });
+          party.spock.spark.mercury.connect();
+        });
+      });
+
+      describe('Board Realtime', function() {
+        beforeEach(function() {
+          uniqueRealtimeData = uuid.v4();
+          return Promise.all(map(party, function(member) {
+            return member.spark.mercury.connect()
+              .then(function() {
+                return member.spark.board.realtime.connectToSharedMercury(board);
+              });
+          }));
+        });
+
+        afterEach(function() {
+          return Promise.all(map(party, function(member) {
+            return member.spark.mercury.disconnect()
+              .then(function() {
+                return member.spark.board.realtime.disconnectFromSharedMercury(board);
+              });
+          }));
+        });
+
+        it('can register and connect to the shared mercury connection', function() {
+          return party.spock.spark.board.realtime.connectToSharedMercury(board)
+            .then(function(res) {
+              assert.property(res, 'action');
+              assert.property(res, 'binding');
+              assert.property(res, 'webSocketUrl');
+              assert.property(res, 'sharedWebSocket');
+              assert.property(res, 'mercuryConnectionServiceClusterUrl');
+              assert.equal(res.action, 'REPLACE');
+              assert.deepEqual(res.mercuryConnectionServiceClusterUrl, party.spock.spark.mercury.localClusterServiceUrls.mercuryConnectionServiceClusterUrl);
+            });
+        });
+
+        it('can disconnect from shared mercury connection', function() {
+          return party.spock.spark.board.realtime.disconnectFromSharedMercury(board)
+            .then(function(res) {
+              assert.property(res, 'action');
+              assert.property(res, 'binding');
+              assert.property(res, 'webSocketUrl');
+              assert.property(res, 'sharedWebSocket');
+              assert.equal(res.action, 'REMOVE');
+            });
+        });
+
+        it('can send and recieve messages', function(done) {
+          var data = {
+            envelope: {
+              channelId: board,
+              roomId: conversation.id
+            },
+            payload: {
+              msg: uniqueRealtimeData
+            }
+          };
+
+          // mccoy is going to listen for mercury data and confirm that we have the
+          // same data that was sent.
+          party.mccoy.spark.mercury.once('board.activity', function(boardData) {
+            assert.equal(boardData.contentType, 'STRING');
+            assert.equal(boardData.payload.msg, uniqueRealtimeData);
+            done();
+          });
+
+          // confirm that both are listening.
+          assert(party.spock.spark.mercury.connected, 'spock is not listening');
+          assert(party.mccoy.spark.mercury.connected, 'mccoy is not listening');
+
+          // do not return promise because we want done() to be called on
+          // board.activity
+          party.spock.spark.board.realtime.publish(board, data);
+          return party.mccoy.spark.board.realtime.connectToSharedMercury(board);
+        });
+      });
+    });
+  });
+});

--- a/test/integration/spec/services/board/sharable-mercury.js
+++ b/test/integration/spec/services/board/sharable-mercury.js
@@ -53,7 +53,7 @@ describe('Services', function() {
           return party.spock.spark.feature.setFeature('developer', 'web-shared-mercury', true);
         })
         .then(function() {
-          return party.mccoy.spark.feature.setFeature('developer', 'web-shared-mercury', true);
+          return party.mccoy.spark.feature.setFeature('developer', 'web-shared-mercury', false);
         });
     });
 
@@ -95,7 +95,7 @@ describe('Services', function() {
     describe('Sharing Mercury', function() {
       describe('Mercury', function() {
         it('connects to mercury and gets registration status', function(done) {
-          party.spock.spark.mercury.on('mercury.registration_status', function(event) {
+          party.spock.spark.mercury.once('mercury.registration_status', function(event) {
             assert.property(event, 'bufferState');
             assert.property(event, 'localClusterServiceUrls');
             assert.deepEqual(party.spock.spark.mercury.localClusterServiceUrls, event.localClusterServiceUrls);
@@ -107,7 +107,7 @@ describe('Services', function() {
 
       describe('Board Realtime', function() {
         describe('connect and reconnect', function() {
-          it('registers and connect to the shared mercury connection', function() {
+          it('registers and connects to the shared mercury connection', function() {
             return party.spock.spark.board.realtime.connectToSharedMercury(board)
               .then(function(res) {
                 assert.property(res, 'action');
@@ -132,53 +132,99 @@ describe('Services', function() {
           });
         });
 
-        describe('sending messages', function() {
+        describe('when messages are sent between shared and non-shared connections', function() {
           beforeEach(function() {
             uniqueRealtimeData = uuid.v4();
             return Promise.all(map(party, function(member) {
-              return member.spark.mercury.connect()
-                .then(function() {
-                  return member.spark.board.realtime.connectToSharedMercury(board);
-                });
-            }));
+              return member.spark.mercury.connect();
+            }))
+              .then(function() {
+                return Promise.all([
+                  party.spock.spark.board.realtime.connectToSharedMercury(board),
+                  party.mccoy.spark.board.realtime.connectByOpenNewMercuryConnection(board)
+                ]);
+              });
           });
 
           afterEach(function() {
             return Promise.all(map(party, function(member) {
               return member.spark.mercury.disconnect()
                 .then(function() {
+                  if (!member.spark.board.realtime.isSharingMercury) {
+                    return member.spark.board.realtime.disconnect();
+                  }
                   return member.spark.board.realtime.disconnectFromSharedMercury(board);
                 });
             }));
           });
 
+          describe('when a message is sent from the shared connection', function() {
+            it('can be received by another separated connection', function(done) {
+              var data = {
+                envelope: {
+                  channelId: board,
+                  roomId: conversation.id
+                },
+                payload: {
+                  msg: uniqueRealtimeData
+                }
+              };
 
-          it('can send and recieve messages', function(done) {
-            var data = {
-              envelope: {
-                channelId: board,
-                roomId: conversation.id
-              },
-              payload: {
-                msg: uniqueRealtimeData
-              }
-            };
+              // mccoy is going to listen for mercury data and confirm that we have the
+              // same data that was sent.
+              party.mccoy.spark.board.realtime.once('board.activity', function(boardData) {
+                assert.equal(boardData.contentType, 'STRING');
+                assert.equal(boardData.payload.msg, uniqueRealtimeData);
+                done();
+              });
 
-            // mccoy is going to listen for mercury data and confirm that we have the
-            // same data that was sent.
-            party.mccoy.spark.mercury.once('board.activity', function(boardData) {
-              assert.equal(boardData.contentType, 'STRING');
-              assert.equal(boardData.payload.msg, uniqueRealtimeData);
-              done();
+              // this is to ensure messages come to the realtime one (for non-shared)
+              party.mccoy.spark.mercury.once('board.activity', function() {
+                assert.fail(0, 1, 'messages should come to realtime, not mercury');
+              });
+
+              // confirm that both are listening.
+              assert(party.spock.spark.mercury.connected, 'spock is not listening');
+              assert(party.spock.spark.board.realtime.isSharingMercury, 'spock is not sharing mercury');
+              assert(party.mccoy.spark.mercury.connected, 'mccoy is not listening');
+              assert.isFalse(party.mccoy.spark.board.realtime.isSharingMercury, 'mccoy should not be sharing mercury');
+
+              // do not return promise because we want done() to be called on
+              // board.activity
+              party.spock.spark.board.realtime.publish(board, data);
             });
+          });
 
-            // confirm that both are listening.
-            assert(party.spock.spark.mercury.connected, 'spock is not listening');
-            assert(party.mccoy.spark.mercury.connected, 'mccoy is not listening');
+          describe('when a message is sent from the separated connection', function() {
+            it('can be received by the shared connection', function(done) {
+              var data = {
+                envelope: {
+                  channelId: board,
+                  roomId: conversation.id
+                },
+                payload: {
+                  msg: uniqueRealtimeData
+                }
+              };
 
-            // do not return promise because we want done() to be called on
-            // board.activity
-            party.spock.spark.board.realtime.publish(board, data);
+              // spock is listening for mercury data and confirm that we have the
+              // same data that was sent.
+              party.spock.spark.mercury.once('board.activity', function(boardData) {
+                assert.equal(boardData.contentType, 'STRING');
+                assert.equal(boardData.payload.msg, uniqueRealtimeData);
+                done();
+              });
+
+              // confirm that both are listening.
+              assert(party.spock.spark.mercury.connected, 'spock is not listening');
+              assert(party.spock.spark.board.realtime.isSharingMercury, 'spock is not sharing mercury');
+              assert(party.mccoy.spark.mercury.connected, 'mccoy is not listening');
+              assert.isFalse(party.mccoy.spark.board.realtime.isSharingMercury, 'mccoy should not be sharing mercury');
+
+              // do not return promise because we want done() to be called on
+              // board.activity
+              party.mccoy.spark.board.realtime.publish(board, data);
+            });
           });
         });
       });

--- a/test/integration/spec/services/board/sharable-mercury.js
+++ b/test/integration/spec/services/board/sharable-mercury.js
@@ -50,10 +50,10 @@ describe('Services', function() {
     before(function beamDown() {
       return landingparty.beamDown(party)
         .then(function() {
-          return party.spock.spark.feature.setFeature('developer', 'web-sharable-mercury', true);
+          return party.spock.spark.feature.setFeature('developer', 'web-shared-mercury', true);
         })
         .then(function() {
-          return party.mccoy.spark.feature.setFeature('developer', 'web-sharable-mercury', true);
+          return party.mccoy.spark.feature.setFeature('developer', 'web-shared-mercury', true);
         });
     });
 
@@ -86,9 +86,9 @@ describe('Services', function() {
     });
 
     after(function cleanUpFeatureToggles() {
-      return party.spock.spark.feature.setFeature('developer', 'web-sharable-mercury', false)
+      return party.spock.spark.feature.setFeature('developer', 'web-shared-mercury', false)
         .then(function() {
-          return party.mccoy.spark.feature.setFeature('developer', 'web-sharable-mercury', false);
+          return party.mccoy.spark.feature.setFeature('developer', 'web-shared-mercury', false);
         });
     });
 

--- a/test/unit/spec/client/mercury/mercury.js
+++ b/test/unit/spec/client/mercury/mercury.js
@@ -142,7 +142,7 @@ describe('Client', function() {
           });
       });
 
-      describe('when web-sharable-socket feature is enabled', function() {
+      describe('when web-shared-socket feature is enabled', function() {
         beforeEach(function() {
           spark.feature.getFeature.returns(true);
         });

--- a/test/unit/spec/client/mercury/mercury.js
+++ b/test/unit/spec/client/mercury/mercury.js
@@ -35,7 +35,10 @@ describe('Client', function() {
 
       spark.logger = console;
 
+      spark.feature.getFeature.returns(false);
+
       socket = new MockSocket();
+      socket._addQueryParameter = Socket.prototype._addQueryParameter;
       socketOpenStub = socket.open;
       socketOpenStub.returns(Promise.resolve());
 
@@ -137,6 +140,21 @@ describe('Client', function() {
           .then(function() {
             assert.calledOnce(socket.open);
           });
+      });
+
+      describe('when web-sharable-socket feature is enabled', function() {
+        beforeEach(function() {
+          spark.feature.getFeature.returns(true);
+        });
+
+        it('sets mercuryRegistrationStatus=true to web socket url', function() {
+          return mercury.connect()
+            .then(function() {
+              console.log(socket._addQueryParameter);
+              assert.calledWith(socket.open, sinon.match(/mercuryRegistrationStatus=true/), sinon.match.any);
+              assert.calledWith(socket.open, sinon.match(/isRegistrationRefreshEnabled=true/), sinon.match.any);
+            });
+        });
       });
 
       describe('when `maxRetries` is set', function() {

--- a/test/unit/spec/client/mercury/mercury.js
+++ b/test/unit/spec/client/mercury/mercury.js
@@ -150,7 +150,6 @@ describe('Client', function() {
         it('sets mercuryRegistrationStatus=true to web socket url', function() {
           return mercury.connect()
             .then(function() {
-              console.log(socket._addQueryParameter);
               assert.calledWith(socket.open, sinon.match(/mercuryRegistrationStatus=true/), sinon.match.any);
               assert.calledWith(socket.open, sinon.match(/isRegistrationRefreshEnabled=true/), sinon.match.any);
             });

--- a/test/unit/spec/client/mercury/socket.js
+++ b/test/unit/spec/client/mercury/socket.js
@@ -231,6 +231,13 @@ describe('Client', function() {
           assert.equal(s.url, 'ws://example.com?queryparam=something&outboundWireFormat=text&bufferStates=true');
         });
 
+        it('does not add bufferStates if mercuryRegistrationStatus is present', function() {
+          var s = new Socket();
+          s.open('ws://example.com?mercuryRegistrationStatus=true', mockoptions);
+          assert.match(s.url, /outboundWireFormat=text/);
+          assert.equal(s.url, 'ws://example.com?mercuryRegistrationStatus=true&outboundWireFormat=text');
+        });
+
         it('does not duplicate url queries', function() {
           var s = new Socket();
           s.open('ws://example.com?outboundWireFormat=text&bufferStates=true', mockoptions);

--- a/test/unit/spec/services/board/board.js
+++ b/test/unit/spec/services/board/board.js
@@ -330,5 +330,19 @@ describe('Services', function() {
         });
       });
     });
+
+    describe('#boardChannelIdToMercuryBinding', function() {
+      it('adds .board binding prefix', function() {
+        assert.equal(spark.board.boardChannelIdToMercuryBinding('test'), 'board.test');
+      });
+
+      it('replaces `-` with `.` and `_` with `#`', function() {
+        assert.equal(spark.board.boardChannelIdToMercuryBinding('abc-1234_bcd'), 'board.abc.1234#bcd');
+      });
+
+      it('leaves strings without - and _ alone', function() {
+        assert.equal(spark.board.boardChannelIdToMercuryBinding('abcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()+='), 'board.abcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()+=');
+      });
+    });
   });
 });

--- a/test/unit/spec/services/board/board.js
+++ b/test/unit/spec/services/board/board.js
@@ -332,7 +332,7 @@ describe('Services', function() {
     });
 
     describe('#boardChannelIdToMercuryBinding', function() {
-      it('adds .board binding prefix', function() {
+      it('adds board. binding prefix', function() {
         assert.equal(spark.board.boardChannelIdToMercuryBinding('test'), 'board.test');
       });
 

--- a/test/unit/spec/services/board/persistence.js
+++ b/test/unit/spec/services/board/persistence.js
@@ -135,7 +135,7 @@ describe('Services', function() {
         });
       });
 
-      describe('#registerForSharingMercury()', function() {
+      describe('#registerToShareMercury()', function() {
 
         beforeEach(function() {
           spark.request.reset();
@@ -144,7 +144,7 @@ describe('Services', function() {
         });
 
         it('requests POST to board service', function() {
-          return spark.board.persistence.registerForSharingMercury(channel)
+          return spark.board.persistence.registerToShareMercury(channel)
             .then(function() {
               assert.calledWith(spark.request, sinon.match({
                 method: 'POST',
@@ -161,12 +161,12 @@ describe('Services', function() {
 
         it('rejects if `web-sharable-mercury` feature is not enabled', function() {
           spark.feature.getFeature.returns(false);
-          return assert.isRejected(spark.board.persistence.registerForSharingMercury(channel));
+          return assert.isRejected(spark.board.persistence.registerToShareMercury(channel));
         });
 
         it('rejects if localClusterServiceUrls is null', function() {
           spark.mercury.localClusterServiceUrls = null;
-          return assert.isRejected(spark.board.persistence.registerForSharingMercury(channel));
+          return assert.isRejected(spark.board.persistence.registerToShareMercury(channel));
         });
       });
 

--- a/test/unit/spec/services/board/persistence.js
+++ b/test/unit/spec/services/board/persistence.js
@@ -148,8 +148,7 @@ describe('Services', function() {
             .then(function() {
               assert.calledWith(spark.request, sinon.match({
                 method: 'POST',
-                api: 'board',
-                resource: '/channels/' + channel.channelId + '/register',
+                uri: channel.channelUrl + '/register',
                 body: {
                   mercuryConnectionServiceClusterUrl: localClusterServiceUrls.mercuryConnectionServiceClusterUrl,
                   webSocketUrl: webSocketUrl,

--- a/test/unit/spec/services/board/persistence.js
+++ b/test/unit/spec/services/board/persistence.js
@@ -67,6 +67,13 @@ describe('Services', function() {
         kmsMessage: '<encrypted>'
       };
 
+      var localClusterServiceUrls = {
+        mercuryApiServiceClusterUrl: 'https:/mercury-api-a.wbx2.com/v2',
+        mercuryConnectionServiceClusterUrl: 'https://mercury-connection-a.wbx2.com'
+      };
+
+      var webSocketUrl = 'wss://mercury-connection-a.wbx2.com/v1/app/...';
+
       var data1 = {
         contentUrl: channel.channelUrl + '/contents/data1',
         contentId: 'data1',
@@ -103,6 +110,7 @@ describe('Services', function() {
             getUnusedKey: sinon.stub().returns(Promise.resolve(mockKey))
           },
           device: {
+            webSocketUrl: webSocketUrl,
             deviceType: 'FAKE_DEVICE',
             getServiceUrl: function() {
               return boardServiceUrl;
@@ -118,7 +126,7 @@ describe('Services', function() {
           return spark.board.persistence.register({data: 'data'});
         });
 
-        it('requests POST data to registration service', function() {
+        it('requests POST data to board registration service', function() {
           assert.calledWith(spark.request, sinon.match({
             method: 'POST',
             api: 'board',
@@ -126,6 +134,42 @@ describe('Services', function() {
           }));
         });
       });
+
+      describe('#registerForSharingMercury()', function() {
+
+        beforeEach(function() {
+          spark.request.reset();
+          spark.feature.getFeature.returns(true);
+          spark.mercury.localClusterServiceUrls = localClusterServiceUrls;
+        });
+
+        it('requests POST to board service', function() {
+          return spark.board.persistence.registerForSharingMercury(channel)
+            .then(function() {
+              assert.calledWith(spark.request, sinon.match({
+                method: 'POST',
+                api: 'board',
+                resource: '/channels/' + channel.channelId + '/register',
+                body: {
+                  mercuryConnectionServiceClusterUrl: localClusterServiceUrls.mercuryConnectionServiceClusterUrl,
+                  webSocketUrl: webSocketUrl,
+                  action: 'REPLACE'
+                }
+              }));
+            });
+        });
+
+        it('rejects if `web-sharable-mercury` feature is not enabled', function() {
+          spark.feature.getFeature.returns(false);
+          return assert.isRejected(spark.board.persistence.registerForSharingMercury(channel));
+        });
+
+        it('rejects if localClusterServiceUrls is null', function() {
+          spark.mercury.localClusterServiceUrls = null;
+          return assert.isRejected(spark.board.persistence.registerForSharingMercury(channel));
+        });
+      });
+
 
       describe('#createChannel()', function() {
 

--- a/test/unit/spec/services/board/persistence.js
+++ b/test/unit/spec/services/board/persistence.js
@@ -159,7 +159,7 @@ describe('Services', function() {
             });
         });
 
-        it('rejects if `web-sharable-mercury` feature is not enabled', function() {
+        it('rejects if `web-shared-mercury` feature is not enabled', function() {
           spark.feature.getFeature.returns(false);
           return assert.isRejected(spark.board.persistence.registerToShareMercury(channel));
         });

--- a/test/unit/spec/services/board/realtime.js
+++ b/test/unit/spec/services/board/realtime.js
@@ -135,6 +135,43 @@ describe('Services', function() {
         });
       });
 
+      describe('#connectToSharedMercury', function() {
+        var registrationInfo;
+        beforeEach(function() {
+          registrationInfo = {
+            mercuryConnectionServiceClusterUrl: 'https://mercury-connection-a5.wbx2.com/v1',
+            binding: 'board.a85e2f70-528d-11e6-ad98-bd2acefef905',
+            webSocketUrl: 'wss://mercury-connection-a.wbx2.com/v1/apps/wx2/registrations/14d6abda-16de-4e02-bf7c-6d2a0e77ec38/messages',
+            sharedWebSocket:true,
+            action: 'REPLACE'
+          };
+
+          sinon.stub(spark.board.persistence, 'registerToShareMercury').returns(Promise.resolve(registrationInfo));
+        });
+
+        afterEach(function() {
+          spark.board.persistence.registerToShareMercury.restore();
+        });
+
+        it('registers and gets board binding', function() {
+          return spark.board.realtime.connectToSharedMercury()
+            .then(function(res) {
+              assert.deepEqual(res, registrationInfo);
+            });
+        });
+
+        describe('when connection cannot be shared', function() {
+          it('opens a second socket with provided webSocketUrl', function() {
+            registrationInfo.sharedWebSocket = false;
+            return spark.board.realtime.connectToSharedMercury()
+              .then(function(res) {
+                assert.deepEqual(res, registrationInfo);
+                assert.calledWith(socketOpenStub, registrationInfo.webSocketUrl, sinon.match.any);
+              });
+          });
+        });
+      });
+
       describe('#_attemptConnection()', function() {
         it('opens socket', function() {
           return spark.board.realtime._attemptConnection()


### PR DESCRIPTION
For now, sharing web socket is hiding behind the feature toggle `web-shared-mercury`
Two changes are in this PR (let me know if I should split this into two PRs)

## Mercury
When `web-shared-mercury` is enabled, mercury will allow sharing its socket connection,
- webSocketUrl changes from having query parameter `bufferState=true` to `mercuryRegistrationStatus=true&registrationRefreshStatus=true` (`registrationRefreshStatus=true` is a server side toggle, which will be removed when we remove feature toggle)

## Whiteboard realtime
- add two methods to allow adding and removing board bindings from mercury connection
- refactor connectByCreatingNewSocket by combining register() and connect() (before, sdk user needs to manually do those steps)



