### PR TITLE
refactor(common): replace base64 methods implementation with package

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,11 +8,9 @@
   "devMain": "src/index.js",
   "repository": "https://github.com/ciscospark/spark-js-sdk/tree/master/packages/common",
   "dependencies": {
-    "atob": "^1.1.2",
     "babel-polyfill": "^6.3.14",
     "babel-runtime": "^6.3.19",
     "backoff": "^2.4.1",
-    "btoa": "^1.1.2",
     "envify": "^3.4.0",
     "lodash": "^4.13.1",
     "urlsafe-base64": "^1.0.0"
@@ -31,12 +29,6 @@
   },
   "engines": {
     "node": ">=4"
-  },
-  "browser": {
-    "./src/shims/atob.js": "./src/shims/atob.shim.js",
-    "./src/shims/btoa.js": "./src/shims/btoa.shim.js",
-    "./dist/shims/atob.js": "./dist/shims/atob.shim.js",
-    "./dist/shims/btoa.js": "./dist/shims/btoa.shim.js"
   },
   "browserify": {
     "transform": [

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,7 +14,8 @@
     "backoff": "^2.4.1",
     "btoa": "^1.1.2",
     "envify": "^3.4.0",
-    "lodash": "^4.13.1"
+    "lodash": "^4.13.1",
+    "urlsafe-base64": "^1.0.0"
   },
   "devDependencies": {
     "@ciscospark/test-helper-chai": "^0.7.34",

--- a/packages/common/src/base64.js
+++ b/packages/common/src/base64.js
@@ -6,6 +6,7 @@
 import UrlSafeBase64 from 'urlsafe-base64';
 
 /**
+ * Converts a string from a base64url-encoded string
  * @param {string} str
  * @returns {string}
  */
@@ -14,17 +15,22 @@ export function fromBase64url(str) {
 }
 
 /**
- * Converts a string to a base64url-encoded string
- * @param {string} str
+ * Converts a string to a base64url-encoded string. It also accepts a buffer
+ * @param {string|buffer} str
  * @returns {string}
  */
 export function toBase64Url(str) {
-  return UrlSafeBase64.encode(new Buffer(str));
+  let buffer = str;
+  if (!Buffer.isBuffer(buffer)) {
+    buffer = new Buffer(buffer);
+  }
+
+  return UrlSafeBase64.encode(buffer);
 }
 
 /**
- * Converts a string to a base64url-encoded string
- * @param {string} str
+ * Converts a string to a base64url-encoded string. It also accepts a buffer
+ * @param {string|buffer} str
  * @returns {string}
  */
 export function encode(str) {

--- a/packages/common/src/base64.js
+++ b/packages/common/src/base64.js
@@ -3,15 +3,14 @@
  * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
  */
 
-import atob from './shims/atob';
-import btoa from './shims/btoa';
+import UrlSafeBase64 from 'urlsafe-base64';
 
 /**
  * @param {string} str
  * @returns {string}
  */
 export function fromBase64url(str) {
-  return atob(str.replace(/\-/g, `+`).replace(/_/g, `/`));
+  return UrlSafeBase64.decode(str).toString();
 }
 
 /**
@@ -20,10 +19,7 @@ export function fromBase64url(str) {
  * @returns {string}
  */
 export function toBase64Url(str) {
-  return btoa(str)
-    .replace(/\+/g, `-`)
-    .replace(/\//g, `_`)
-    .replace(/\=/g, ``);
+  return UrlSafeBase64.encode(new Buffer(str));
 }
 
 /**

--- a/packages/common/src/shims/atob.js
+++ b/packages/common/src/shims/atob.js
@@ -1,6 +1,0 @@
-/**!
- *
- * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
- */
-
-export {default as default} from 'atob';

--- a/packages/common/src/shims/atob.shim.js
+++ b/packages/common/src/shims/atob.shim.js
@@ -1,8 +1,0 @@
-/**!
- *
- * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
- */
-
- /* eslint-env browser */
-
-export default window.atob;

--- a/packages/common/src/shims/btoa.js
+++ b/packages/common/src/shims/btoa.js
@@ -1,6 +1,0 @@
-/**!
- *
- * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
- */
-
-export {default as default} from 'btoa';

--- a/packages/common/src/shims/btoa.shim.js
+++ b/packages/common/src/shims/btoa.shim.js
@@ -1,8 +1,0 @@
-/**!
- *
- * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
- */
-
-/* eslint-env browser */
-
-export default window.btoa;

--- a/packages/common/test/unit/spec/common.js
+++ b/packages/common/test/unit/spec/common.js
@@ -16,12 +16,19 @@ describe(`common`, () => {
       assert.isDefined(base64);
     });
 
-    it(`does btoa transforms`, () => {
+    it(`encodes string to base64`, () => {
       assert.equal(base64.toBase64Url(`abc`), `YWJj`);
     });
 
-    it(`does atob transforms`, () => {
-      assert.equal(base64.fromBase64url(`YWJj`), `abc`);
+    it(`can encode buffer to base64`, () => {
+      const buffer = new Buffer(`abc`);
+      assert.equal(base64.toBase64Url(buffer), `YWJj`);
+    });
+
+    it(`decodes base64 string to readable string`, () => {
+      const result = base64.fromBase64url(`YWJj`);
+      assert.typeOf(result, `string`, `decoded result must be type of string`);
+      assert.equal(result, `abc`);
     });
   });
 

--- a/packages/common/test/unit/spec/common.js
+++ b/packages/common/test/unit/spec/common.js
@@ -16,16 +16,16 @@ describe(`common`, () => {
       assert.isDefined(base64);
     });
 
-    it(`encodes string to base64`, () => {
+    it(`base64-encodes a string`, () => {
       assert.equal(base64.toBase64Url(`abc`), `YWJj`);
     });
 
-    it(`can encode buffer to base64`, () => {
+    it(`base64-encodes a buffer`, () => {
       const buffer = new Buffer(`abc`);
       assert.equal(base64.toBase64Url(buffer), `YWJj`);
     });
 
-    it(`decodes base64 string to readable string`, () => {
+    it(`base64-decodes a string`, () => {
       const result = base64.fromBase64url(`YWJj`);
       assert.typeOf(result, `string`, `decoded result must be type of string`);
       assert.equal(result, `abc`);


### PR DESCRIPTION
use urlsafe-base64 package as similar to node-jose

resolves #95 

