### PR TITLE
fix(plugin-encryption): Utilize spark:kms scope

### DIFF
--- a/packages/plugin-encryption/src/kms.js
+++ b/packages/plugin-encryption/src/kms.js
@@ -314,7 +314,7 @@ const KMS = SparkPlugin.extend({
   _getAuthorization() {
     // Remove the `Bearer` prefix from the token; we'll improve this when we add
     // token downscoping.
-    return this.spark.credentials.getAuthorization()
+    return this.spark.credentials.getAuthorization(`spark:kms`)
       .then((authorization) => authorization.toString().replace(/[Bb]earer\s+/, ``));
   },
 


### PR DESCRIPTION
Pass spark:kms to spark.credentials.getAuthorization(). @ianwremmel - should there be a unit test for this? I checked for an existing one but couldn't find it. On top of that, I failed to get the tests to run locally following the README. Happy to share the console output. 

