### PR TITLE
fix(spark-core): interceptors ignore plugin-logger

### DIFF
--- a/packages/spark-core/src/interceptors/request-logger.js
+++ b/packages/spark-core/src/interceptors/request-logger.js
@@ -16,7 +16,7 @@ export default class RequestLoggerInterceptor extends Interceptor {
    * @returns {RequestLoggerInterceptor}
    */
   static create() {
-    return new RequestLoggerInterceptor(this);
+    return new RequestLoggerInterceptor({spark: this});
   }
 
   /**

--- a/packages/spark-core/src/interceptors/request-logger.js
+++ b/packages/spark-core/src/interceptors/request-logger.js
@@ -25,7 +25,7 @@ export default class RequestLoggerInterceptor extends Interceptor {
    * @returns {Object}
    */
   onRequest(options) {
-    const logger = get(options, `logger`, console);
+    const logger = get(this, `spark.logger`, console);
     logger.log(`/**********************************************************************\\ `);
     logger.log(`Request:`, options.method || `GET`, options.uri);
     logger.log(`WEBEX_TRACKINGID: `, get(options, `headers.trackingid`));
@@ -67,7 +67,7 @@ export default class RequestLoggerInterceptor extends Interceptor {
     // We need to do the normal onRequest logging, but then log how the request
     // failed since the response logger won't be called.
     this.onRequest(options);
-    const logger = get(options, `logger`, console);
+    const logger = get(this, `spark.logger`, console);
     logger.error(`Request Failed: `, reason.stack);
     logger.log(`\\**********************************************************************/`);
 

--- a/packages/spark-core/src/interceptors/response-logger.js
+++ b/packages/spark-core/src/interceptors/response-logger.js
@@ -16,7 +16,7 @@ export default class ResponseLoggerInterceptor extends Interceptor {
    * @returns {ResponseLoggerInterceptor}
    */
   static create() {
-    return new ResponseLoggerInterceptor(this);
+    return new ResponseLoggerInterceptor({spark: this});
   }
 
   /**

--- a/packages/spark-core/src/interceptors/response-logger.js
+++ b/packages/spark-core/src/interceptors/response-logger.js
@@ -29,7 +29,7 @@ export default class ResponseLoggerInterceptor extends Interceptor {
     const now = new Date();
     this.printResponseHeader(options, response);
 
-    const logger = get(options, `logger`, console);
+    const logger = get(this, `spark.logger`, console);
     if (process.env.ENABLE_VERBOSE_NETWORK_LOGGING) {
       logger.log(`timestamp (end): `, now.getTime(), now.toISOString());
       if (typeof response.body === `string` || Buffer.isBuffer(response.body)) {
@@ -59,7 +59,7 @@ export default class ResponseLoggerInterceptor extends Interceptor {
     const now = new Date();
     this.printResponseHeader(options, reason);
 
-    const logger = get(options, `logger`, console);
+    const logger = get(this, `spark.logger`, console);
     if (process.env.ENABLE_VERBOSE_NETWORK_LOGGING) {
       logger.log(`timestamp (end): `, now.getTime(), now.toISOString());
       try {
@@ -81,7 +81,7 @@ export default class ResponseLoggerInterceptor extends Interceptor {
    * @returns {undefined}
    */
   printResponseHeader(options, response) {
-    const logger = get(options, `logger`, console);
+    const logger = get(this, `spark.logger`, console);
     logger.log(`Status Code:`, response.statusCode);
     logger.log(`WEBEX_TRACKINGID:`, get(options, `headers.trackingid`) || get(response, `headers.trackingid`));
     logger.log(`Network duration:`, options.$timings.networkEnd - options.$timings.networkStart);


### PR DESCRIPTION
I kept the `console` as a fall-back, just in case; AFAIK, `options.logger` was the wrong reference.

It's not the case (without the work of yet another interceptor) that the `logger` is on `options`.

Effectively, this meant (for us, and likely others) that logging would always fall-back to `console`.

IIRC, the interceptor's `this` reference has a `spark`, on which the `logger` plugin is registered.

Also cross-referencing #441 for an oft-related (and still existing, but minor) issue involving replacing the `logger`. We hacked around that issue by explicitly registering the stock `logger` plugin first, then replacing it with our own, which works for us since we never use the default instance.