### PR TITLE
chore(eslint-config): upgrade to jsx-a11y 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "eslint": "^3.14.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx": "0.0.2",
-    "eslint-plugin-jsx-a11y": "^3.0.2",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-mocha": "^4.8.0",
     "eslint-plugin-react": "^6.9.0",
     "file-loader": "^0.9.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,7 +14,7 @@
     "babel-eslint": "^7.1.1",
     "eslint": ">= 3",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^3.0.2",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-react": "^6.8.0"
   },

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -242,7 +242,7 @@ module.exports = {
     'jsx-a11y/no-access-key': [
       2
     ],
-    'jsx-a11y/no-marquee': [
+    'jsx-a11y/no-distracting-elements': [
       2
     ],
     'jsx-a11y/no-onchange': [


### PR DESCRIPTION
The `no-marquee` rule was changed in 4.0.0. We need this update to come through because apparently we can't have 4.0.0 in the react repo and 3.X in the `@ciscospark/eslint-config` package.