### PR TITLE
fix(plugin-encryption): update to node-jose 0.9.3 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "lodash.values": "^3.0.0",
     "lodash.where": "^3.1.0",
     "mmmagic": "~0.3.14",
-    "node-jose": "~0.9.0",
+    "node-jose": "~0.9.3",
     "node-kms": "~0.3.1",
     "node-scr": "~0.2.1",
     "request": "~2.55.0",

--- a/packages/plugin-encryption/package.json
+++ b/packages/plugin-encryption/package.json
@@ -16,7 +16,7 @@
     "@ciscospark/spark-core": "^0.7.71",
     "babel-runtime": "^6.3.19",
     "lodash": "^4.13.1",
-    "node-jose": "^0.9.1",
+    "node-jose": "^0.9.3",
     "node-kms": "^0.3.2",
     "node-scr": "^0.2.2"
   },


### PR DESCRIPTION
A critical vulnerability was found in many jose implementations.
node-jose@0.9.3 address the vulnerability.