### PR TITLE
fix(board): ensure board creator does not get authorized to board KRO

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/src/board.js
@@ -5,7 +5,7 @@
  */
 
 import {SparkPlugin, Page} from '@ciscospark/spark-core';
-import {base64} from '@ciscospark/common';
+import {base64, tap} from '@ciscospark/common';
 import Realtime from './realtime';
 import {assign, defaults, chunk, pick, some} from 'lodash';
 import querystring from 'querystring';
@@ -115,7 +115,8 @@ const Board = SparkPlugin.extend({
       resource: `/channels`,
       body: this._prepareChannel(conversation, channel)
     })
-      .then((res) => this._ensureOnlyConversationAuthorization(res.body));
+      .then((res) => res.body)
+      .then(tap((body) => this._ensureOnlyConversationAuthorization(body)));
   },
 
   _prepareChannel(conversation, channel) {
@@ -131,20 +132,20 @@ const Board = SparkPlugin.extend({
   },
 
   _ensureOnlyConversationAuthorization(channel) {
-    if (!this._isChannelCreatorAuthorized(channel.creatorId, channel.kmsMessage)) {
-      return Promise.resolve(channel);
-    }
+    // keep this function out of the critical path of creating a board
+    process.nextTick(() => {
+      if (this._isChannelCreatorAuthorized(channel.creatorId, channel.kmsMessage)) {
+        // remove channel creator from board service kms as we want to link to
+        // conversation KRO only
+        const kmsMessage = {
+          method: `delete`,
+          uri: `${channel.kmsMessage.resource.uri}/authorizations?${querystring.stringify({authId: channel.creatorId})}`
+        };
 
-    // remove channel creator from board service kms as we want to link to
-    // conversation KRO only
-    const kmsMessage = {
-      method: `delete`,
-      uri: `${channel.kmsMessage.resource.uri}/authorizations?${querystring.stringify({authId: channel.creatorId})}`
-    };
-
-    return this.spark.encryption.kms.prepareRequest(kmsMessage)
-      .then((req) => this.spark.encryption.kms.request(req))
-      .then(() => channel);
+        this.spark.encryption.kms.prepareRequest(kmsMessage)
+          .then((req) => this.spark.encryption.kms.request(req));
+      }
+    });
   },
 
   _isChannelCreatorAuthorized(creatorId, kmsMessage) {

--- a/packages/node_modules/@ciscospark/plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/src/board.js
@@ -5,8 +5,11 @@
  */
 
 import {SparkPlugin, Page} from '@ciscospark/spark-core';
+import {base64} from '@ciscospark/common';
 import Realtime from './realtime';
-import {assign, defaults, chunk, pick} from 'lodash';
+import {assign, defaults, chunk, pick, some} from 'lodash';
+import querystring from 'querystring';
+
 import promiseSeries from 'es6-promise-series';
 
 const Board = SparkPlugin.extend({
@@ -112,7 +115,7 @@ const Board = SparkPlugin.extend({
       resource: `/channels`,
       body: this._prepareChannel(conversation, channel)
     })
-      .then((res) => res.body);
+      .then((res) => this._ensureOnlyConversationAuthorization(res.body));
   },
 
   _prepareChannel(conversation, channel) {
@@ -125,6 +128,28 @@ const Board = SparkPlugin.extend({
         keyUris: []
       }
     }, channel);
+  },
+
+  _ensureOnlyConversationAuthorization(channel) {
+    if (!this._isChannelCreatorAuthorized(channel.creatorId, channel.kmsMessage)) {
+      return Promise.resolve(channel);
+    }
+
+    // remove channel creator from board service kms as we want to link to
+    // conversation KRO only
+    const kmsMessage = {
+      method: `delete`,
+      uri: `${channel.kmsMessage.resource.uri}/authorizations?${querystring.stringify({authId: channel.creatorId})}`
+    };
+
+    return this.spark.encryption.kms.prepareRequest(kmsMessage)
+      .then((req) => this.spark.encryption.kms.request(req))
+      .then(() => channel);
+  },
+
+  _isChannelCreatorAuthorized(creatorId, kmsMessage) {
+    const authorizationUris = kmsMessage.resource.authorizationUris;
+    return some(authorizationUris, (uri) => base64.fromBase64url(uri).includes(creatorId));
   },
 
   /**

--- a/packages/node_modules/@ciscospark/plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/src/board.js
@@ -8,7 +8,6 @@ import {SparkPlugin, Page} from '@ciscospark/spark-core';
 import {base64, tap} from '@ciscospark/common';
 import Realtime from './realtime';
 import {assign, defaults, chunk, pick, some} from 'lodash';
-import querystring from 'querystring';
 
 import promiseSeries from 'es6-promise-series';
 
@@ -137,13 +136,10 @@ const Board = SparkPlugin.extend({
       if (this._isChannelCreatorAuthorized(channel.creatorId, channel.kmsMessage)) {
         // remove channel creator from board service kms as we want to link to
         // conversation KRO only
-        const kmsMessage = {
-          method: `delete`,
-          uri: `${channel.kmsMessage.resource.uri}/authorizations?${querystring.stringify({authId: channel.creatorId})}`
-        };
-
-        this.spark.encryption.kms.prepareRequest(kmsMessage)
-          .then((req) => this.spark.encryption.kms.request(req));
+        this.spark.encryption.kms.removeAuthorization({
+          authId: channel.creatorId,
+          resourceUri: channel.kmsMessage.resource.uri
+        });
       }
     });
   },

--- a/packages/node_modules/@ciscospark/plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/src/board.js
@@ -138,7 +138,7 @@ const Board = SparkPlugin.extend({
         // conversation KRO only
         this.spark.encryption.kms.removeAuthorization({
           authId: channel.creatorId,
-          resourceUri: channel.kmsMessage.resource.uri
+          kroUri: channel.kmsMessage.resource.uri
         });
       }
     });

--- a/packages/node_modules/@ciscospark/plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/test/integration/spec/board.js
@@ -355,5 +355,82 @@ describe(`plugin-board`, () => {
           });
       });
     });
+
+    describe(`when a user leaves conversation`, () => {
+      it(`does not allow board user to access contents`, () => {
+        let currentConvo;
+        let currentBoard;
+        const encryptedBoardContent = {};
+        const data = [{
+          type: `curve`,
+          payload: JSON.stringify({type: `curve`})
+        }];
+
+        return participants[0].spark.conversation.create({
+          displayName: `Test Board Member Leave Conversation`,
+          participants
+        })
+          .then((c) => {
+            currentConvo = c;
+            return participants[0].spark.board.createChannel(currentConvo);
+          })
+          .then((b) => {
+            currentBoard = b;
+            return participants[1].spark.board.encryptContents(currentBoard.defaultEncryptionKeyUrl, data);
+          })
+          .then((encryptedData) => {
+            encryptedBoardContent.items = encryptedData;
+            return participants[1].spark.conversation.leave(currentConvo);
+          })
+          .then(() => {
+            return assert.isRejected(participants[1].spark.board.getContents(currentBoard));
+          })
+          .then(() => {
+            // make sure the key isn't cached
+            return participants[1].spark.unboundedStorage.clear();
+          })
+          .then(() => {
+            return assert.isRejected(participants[1].spark.board.decryptContents(encryptedBoardContent));
+          });
+      });
+
+      it(`does not allow board creator to access and decrypt contents`, () => {
+        let currentConvo;
+        let currentBoard;
+        const encryptedBoardContent = {};
+        const data = [{
+          type: `curve`,
+          payload: JSON.stringify({type: `curve`})
+        }];
+
+        return participants[1].spark.conversation.create({
+          displayName: `Test Board Creator Leave Conversation`,
+          participants
+        })
+          .then((c) => {
+            currentConvo = c;
+            return participants[1].spark.board.createChannel(currentConvo);
+          })
+          .then((b) => {
+            currentBoard = b;
+            return participants[1].spark.conversation.leave(currentConvo);
+          })
+          .then(() => {
+            return participants[0].spark.board.encryptContents(currentBoard.defaultEncryptionKeyUrl, data);
+          })
+          .then((encryptedData) => {
+            encryptedBoardContent.items = encryptedData;
+            return assert.isRejected(participants[1].spark.board.getContents(currentBoard));
+          })
+          .then(() => {
+            // ensure keys aren't cached
+            return participants[1].spark.unboundedStorage.clear();
+          })
+          .then(() => {
+            return assert.isRejected(participants[1].spark.board.decryptContents(encryptedBoardContent));
+          });
+      });
+    });
+
   });
 });

--- a/packages/node_modules/@ciscospark/plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/test/integration/spec/board.js
@@ -357,14 +357,8 @@ describe(`plugin-board`, () => {
     });
 
     describe(`when a user leaves conversation`, () => {
-      it(`does not allow board user to access contents`, () => {
+      it(`does not allow board user to create board`, () => {
         let currentConvo;
-        let currentBoard;
-        const encryptedBoardContent = {};
-        const data = [{
-          type: `curve`,
-          payload: JSON.stringify({type: `curve`})
-        }];
 
         return participants[0].spark.conversation.create({
           displayName: `Test Board Member Leave Conversation`,
@@ -372,26 +366,9 @@ describe(`plugin-board`, () => {
         })
           .then((c) => {
             currentConvo = c;
-            return participants[0].spark.board.createChannel(currentConvo);
-          })
-          .then((b) => {
-            currentBoard = b;
-            return participants[1].spark.board.encryptContents(currentBoard.defaultEncryptionKeyUrl, data);
-          })
-          .then((encryptedData) => {
-            encryptedBoardContent.items = encryptedData;
             return participants[1].spark.conversation.leave(currentConvo);
           })
-          .then(() => {
-            return assert.isRejected(participants[1].spark.board.getContents(currentBoard));
-          })
-          .then(() => {
-            // make sure the key isn't cached
-            return participants[1].spark.unboundedStorage.clear();
-          })
-          .then(() => {
-            return assert.isRejected(participants[1].spark.board.decryptContents(encryptedBoardContent));
-          });
+          .then(() => assert.isRejected(participants[1].spark.board.createChannel(currentConvo)));
       });
 
       it(`does not allow board creator to access and decrypt contents`, () => {
@@ -415,20 +392,14 @@ describe(`plugin-board`, () => {
             currentBoard = b;
             return participants[1].spark.conversation.leave(currentConvo);
           })
-          .then(() => {
-            return participants[0].spark.board.encryptContents(currentBoard.defaultEncryptionKeyUrl, data);
-          })
+          .then(() => participants[0].spark.board.encryptContents(currentBoard.defaultEncryptionKeyUrl, data))
           .then((encryptedData) => {
             encryptedBoardContent.items = encryptedData;
             return assert.isRejected(participants[1].spark.board.getContents(currentBoard));
           })
-          .then(() => {
-            // ensure keys aren't cached
-            return participants[1].spark.unboundedStorage.clear();
-          })
-          .then(() => {
-            return assert.isRejected(participants[1].spark.board.decryptContents(encryptedBoardContent));
-          });
+          // ensure keys aren't cached
+          .then(() => participants[1].spark.unboundedStorage.clear())
+          .then(() => assert.isRejected(participants[1].spark.board.decryptContents(encryptedBoardContent)));
       });
     });
 

--- a/packages/node_modules/@ciscospark/plugin-board/test/unit/spec/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/test/unit/spec/board.js
@@ -107,8 +107,7 @@ describe(`plugin-board`, () => {
         decryptScr: sinon.stub().returns(Promise.resolve(`decryptedFoo`)),
         encryptScr: sinon.stub().returns(Promise.resolve(`encryptedFoo`)),
         kms: {
-          prepareRequest: sinon.stub().returns(Promise.resolve()),
-          request: sinon.stub().returns(Promise.resolve())
+          removeAuthorization: sinon.stub().returns(Promise.resolve())
         }
       },
       request: sinon.stub().returns(Promise.resolve({
@@ -203,8 +202,7 @@ describe(`plugin-board`, () => {
     before(() => {
       spark.request.reset();
       spark.request.returns(Promise.resolve({statusCode: 200, body: channelRes}));
-      spark.encryption.kms.request.reset();
-      spark.encryption.kms.prepareRequest.reset();
+      spark.encryption.kms.removeAuthorization.reset();
       return spark.board.createChannel(conversation);
     });
 
@@ -226,11 +224,10 @@ describe(`plugin-board`, () => {
     });
 
     it(`requests to KMS to remove board creator authorization`, () => {
-      assert.calledWith(spark.encryption.kms.prepareRequest, sinon.match({
-        method: `delete`,
-        uri: `${channelRes.kmsMessage.resource.uri}/authorizations?authId=${channelRes.creatorId}`
+      assert.calledWith(spark.encryption.kms.removeAuthorization, sinon.match({
+        resourceUri: channelRes.kmsMessage.resource.uri,
+        authId: channelRes.creatorId
       }));
-      assert.called(spark.encryption.kms.request);
     });
 
     it(`does not request to KMS to remove board creator if board creator is not authorized`, () => {
@@ -253,12 +250,10 @@ describe(`plugin-board`, () => {
       };
 
       spark.request.returns(Promise.resolve({statusCode: 200, body: channelRes}));
-      spark.encryption.kms.request.reset();
-      spark.encryption.kms.prepareRequest.reset();
+      spark.encryption.kms.removeAuthorization.reset();
       return spark.board.createChannel(conversation)
         .then(() => {
-          assert.notCalled(spark.encryption.kms.prepareRequest);
-          assert.notCalled(spark.encryption.kms.request);
+          assert.notCalled(spark.encryption.kms.removeAuthorization);
         });
     });
   });

--- a/packages/node_modules/@ciscospark/plugin-board/test/unit/spec/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/test/unit/spec/board.js
@@ -47,6 +47,25 @@ describe(`plugin-board`, () => {
     }
   };
 
+  const channelRes = {
+    channelUrl: `${boardServiceUrl}/channels/${boardId}`,
+    channelId: boardId,
+    aclUrlLink: conversation.aclUrl,
+    defaultEncryptionKeyUrl: mockKey.uri,
+    creatorId: `c321e329-28d6-4d52-a9d1-374010411530`,
+    kmsMessage: {
+      status: 201,
+      resource: {
+        uri: `https://encryption-a.wbx2.com/encryption/api/v1/resources/2853285c-c46b-4b35-9542-9a81d4e3c87f`,
+        keyUris: [`https://encryption-a.wbx2.com/encryption/api/v1/keys/5042787d-510b-46f3-b83c-ea73032de851`],
+        authorizationUris: [
+          `https://encryption-a.wbx2.com/encryption/api/v1/authorizations/aHR0cHM6Ly9lbmNyeXB0aW9uLWEud2J4Mi5jb20vZW5jcnlwdGlvbi9hcGkvdjEvcmVzb3VyY2VzLzI3OWIyMjgyLWZmYTItNGM3ZC04NGRmLTRkNDVlZmUzYTMzNQBodHRwczovL2VuY3J5cHRpb24tYS53YngyLmNvbS9lbmNyeXB0aW9uL2FwaS92MS9yZXNvdXJjZXMvMjg1MzI4NWMtYzQ2Yi00YjM1LTk1NDItOWE4MWQ0ZTNjODdm`,
+          `https://encryption-a.wbx2.com/encryption/api/v1/authorizations/YzMyMWUzMjktMjhkNi00ZDUyLWE5ZDEtMzc0MDEwNDExNTMwAGh0dHBzOi8vZW5jcnlwdGlvbi1hLndieDIuY29tL2VuY3J5cHRpb24vYXBpL3YxL3Jlc291cmNlcy8yODUzMjg1Yy1jNDZiLTRiMzUtOTU0Mi05YTgxZDRlM2M4N2Y`
+        ]
+      }
+    }
+  };
+
   const channelRequestBody = {
     aclUrlLink: channel.aclUrlLink,
     kmsMessage: channel.kmsMessage
@@ -86,7 +105,11 @@ describe(`plugin-board`, () => {
           toArrayBuffer: sinon.stub()
         })),
         decryptScr: sinon.stub().returns(Promise.resolve(`decryptedFoo`)),
-        encryptScr: sinon.stub().returns(Promise.resolve(`encryptedFoo`))
+        encryptScr: sinon.stub().returns(Promise.resolve(`encryptedFoo`)),
+        kms: {
+          prepareRequest: sinon.stub().returns(Promise.resolve()),
+          request: sinon.stub().returns(Promise.resolve())
+        }
       },
       request: sinon.stub().returns(Promise.resolve({
         headers: {},
@@ -179,7 +202,18 @@ describe(`plugin-board`, () => {
 
     before(() => {
       spark.request.reset();
+      spark.request.returns(Promise.resolve({statusCode: 200, body: channelRes}));
+      spark.encryption.kms.request.reset();
+      spark.encryption.kms.prepareRequest.reset();
       return spark.board.createChannel(conversation);
+    });
+
+    after(() => {
+      // reset request to its original behavior
+      spark.request.returns(Promise.resolve({
+        headers: {},
+        body: ``
+      }));
     });
 
     it(`requests POST to channels service`, () => {
@@ -189,6 +223,43 @@ describe(`plugin-board`, () => {
         resource: `/channels`,
         body: channelRequestBody
       }));
+    });
+
+    it(`requests to KMS to remove board creator authorization`, () => {
+      assert.calledWith(spark.encryption.kms.prepareRequest, sinon.match({
+        method: `delete`,
+        uri: `${channelRes.kmsMessage.resource.uri}/authorizations?authId=${channelRes.creatorId}`
+      }));
+      assert.called(spark.encryption.kms.request);
+    });
+
+    it(`does not request to KMS to remove board creator if board creator is not authorized`, () => {
+      const channelRes = {
+        channelUrl: `${boardServiceUrl}/channels/${boardId}`,
+        channelId: boardId,
+        aclUrlLink: conversation.aclUrl,
+        defaultEncryptionKeyUrl: mockKey.uri,
+        creatorId: `c321e329-28d6-4d52-a9d1-374010411530`,
+        kmsMessage: {
+          status: 201,
+          resource: {
+            uri: `https://encryption-a.wbx2.com/encryption/api/v1/resources/2853285c-c46b-4b35-9542-9a81d4e3c87f`,
+            keyUris: [`https://encryption-a.wbx2.com/encryption/api/v1/keys/5042787d-510b-46f3-b83c-ea73032de851`],
+            authorizationUris: [
+              `https://encryption-a.wbx2.com/encryption/api/v1/authorizations/aHR0cHM6Ly9lbmNyeXB0aW9uLWEud2J4Mi5jb20vZW5jcnlwdGlvbi9hcGkvdjEvcmVzb3VyY2VzLzI3OWIyMjgyLWZmYTItNGM3ZC04NGRmLTRkNDVlZmUzYTMzNQBodHRwczovL2VuY3J5cHRpb24tYS53YngyLmNvbS9lbmNyeXB0aW9uL2FwaS92MS9yZXNvdXJjZXMvMjg1MzI4NWMtYzQ2Yi00YjM1LTk1NDItOWE4MWQ0ZTNjODdm`
+            ]
+          }
+        }
+      };
+
+      spark.request.returns(Promise.resolve({statusCode: 200, body: channelRes}));
+      spark.encryption.kms.request.reset();
+      spark.encryption.kms.prepareRequest.reset();
+      return spark.board.createChannel(conversation)
+        .then(() => {
+          assert.notCalled(spark.encryption.kms.prepareRequest);
+          assert.notCalled(spark.encryption.kms.request);
+        });
     });
   });
 

--- a/packages/node_modules/@ciscospark/plugin-board/test/unit/spec/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/test/unit/spec/board.js
@@ -225,7 +225,7 @@ describe(`plugin-board`, () => {
 
     it(`requests to KMS to remove board creator authorization`, () => {
       assert.calledWith(spark.encryption.kms.removeAuthorization, sinon.match({
-        resourceUri: channelRes.kmsMessage.resource.uri,
+        kroUri: channelRes.kmsMessage.resource.uri,
         authId: channelRes.creatorId
       }));
     });

--- a/packages/node_modules/@ciscospark/plugin-encryption/src/kms.js
+++ b/packages/node_modules/@ciscospark/plugin-encryption/src/kms.js
@@ -10,6 +10,7 @@ import {Context, Request, Response} from 'node-kms';
 import KMSBatcher, {TIMEOUT_SYMBOL} from './kms-batcher';
 import jose from 'node-jose';
 import {omit} from 'lodash';
+import querystring from 'querystring';
 
 const contexts = new WeakMap();
 const kmsDetails = new WeakMap();
@@ -101,6 +102,82 @@ const KMS = SparkPlugin.extend({
       .then((res) => {
         this.logger.info(`kms: created resource`);
         return res.resource;
+      });
+  },
+
+  /**
+   * Authorizes a user or KRO to a KRO
+   * @param {Object} options
+   * @param {Array<string>} options.userIds
+   * @param {Array<string>} options.authIds interchangable with userIds
+   * @param {KMSResourceObject} options.kro the target kro
+   * @param {string} options.kroUri
+   * @returns {Promise<KMSAuthorizationObject>}
+   */
+  addAuthorization({userIds, authIds, kro, kroUri}) {
+    userIds = userIds || [];
+    kroUri = kroUri || kro.uri;
+
+    if (authIds) {
+      userIds = userIds.concat(authIds);
+    }
+
+    /* istanbul ignore if */
+    if (userIds.length === 0) {
+      return Promise.reject(new Error(`Cannot add authorization without userIds or authIds`));
+    }
+
+    /* istanbul ignore if */
+    if (!kroUri) {
+      return Promise.reject(new Error(`\`kro\` or \`kroUri\` is required`));
+    }
+
+    this.logger.info(`kms: adding authorization to kms resource`);
+
+    return this.request({
+      method: `create`,
+      uri: `/authorizations`,
+      resourceUri: kroUri,
+      userIds
+    })
+      .then((res) => {
+        this.logger.info(`kms: added authorization`);
+        return res.authorizations;
+      });
+  },
+
+  /**
+   * Deauthorizes a user or KRO from a KRO
+   * @param {Object} options
+   * @param {string} options.userId
+   * @param {string} options.authId interchangable with userIds
+   * @param {KMSResourceObject} options.kro the target kro
+   * @param {string} options.kroUri
+   * @returns {Promise<KMSAuthorizationObject>}
+   */
+  removeAuthorization({authId, userId, kro, kroUri}) {
+    authId = authId || userId;
+    kroUri = kroUri || kro.uri;
+
+    /* istanbul ignore if */
+    if (!authId) {
+      return Promise.reject(new Error(`Cannot remove authorization without authId`));
+    }
+
+    /* istanbul ignore if */
+    if (!kroUri) {
+      return Promise.reject(new Error(`\`kro\` or \`kroUri\` is required`));
+    }
+
+    this.logger.info(`kms: removing authorization from kms resource`);
+
+    return this.request({
+      method: `delete`,
+      uri: `${kroUri}/authorizations?${querystring.stringify({authId})}`
+    })
+      .then((res) => {
+        this.logger.info(`kms: removed authorization`);
+        return res.authorizations;
       });
   },
 

--- a/packages/node_modules/@ciscospark/plugin-encryption/test/integration/spec/kms.js
+++ b/packages/node_modules/@ciscospark/plugin-encryption/test/integration/spec/kms.js
@@ -15,8 +15,9 @@ describe(`Encryption`, function() {
   this.timeout(30000);
   describe(`KMS`, () => {
     let spark, user;
+    let anotherUser;
 
-    before(`create test user`, () => testUsers.create({count: 1})
+    before(`create test user`, () => testUsers.create({count: 2})
       .then((users) => {
         user = users[0];
         spark = new CiscoSpark({
@@ -25,6 +26,16 @@ describe(`Encryption`, function() {
           }
         });
         assert.isTrue(spark.canAuthorize);
+
+        anotherUser = users[1];
+        anotherUser.spark = new CiscoSpark({
+          credentials: {
+            authorization: anotherUser.token
+          }
+        });
+
+        assert.isTrue(anotherUser.spark.canAuthorize);
+        return anotherUser.spark.device.register();
       }));
 
     after(() => spark && spark.mercury.disconnect());
@@ -46,13 +57,85 @@ describe(`Encryption`, function() {
     });
 
     describe(`#addAuthorization()`, () => {
-      it(`authorizes a user to a key`);
-      it(`authorizes a resource to a key`);
+      let kro, otherKro;
+      before(`create a resource`, () => spark.encryption.kms.createUnboundKeys({count: 1})
+        .then(([key]) => spark.encryption.kms.createResource({
+          key
+        }))
+        .then((k) => {
+          kro = k;
+          assert.lengthOf(kro.authorizationUris, 1);
+        }));
+
+      it(`authorizes a user to a key`, () => spark.encryption.kms.addAuthorization({
+        userIds: [anotherUser.spark.device.userId],
+        kroUri: kro.uri
+      })
+        .then(([auth]) => {
+          assert.equal(auth.resourceUri, kro.uri);
+          assert.equal(auth.authId, anotherUser.spark.device.userId);
+        }));
+
+      it(`authorizes a resource to a key`, () => spark.encryption.kms.createUnboundKeys({count: 1})
+        .then(([key]) => spark.encryption.kms.createResource({key}))
+        .then((k) => {
+          otherKro = k;
+          return spark.encryption.kms.addAuthorization({
+            authIds: [otherKro.uri],
+            kro
+          });
+        })
+        .then(([auth]) => {
+          assert.equal(auth.resourceUri, kro.uri);
+          assert.equal(auth.authId, otherKro.uri);
+        }));
     });
 
     describe(`#removeAuthorization()`, () => {
-      it(`deauthorizes a user from a key`);
-      it(`deauthorizes a resource from a key`);
+      let kro, otherKro;
+      before(`create resource`, () => spark.encryption.kms.createUnboundKeys({count: 1})
+        .then(([key]) => spark.encryption.kms.createResource({
+          key
+        }))
+        .then((k) => {
+          kro = k;
+          assert.lengthOf(kro.authorizationUris, 1);
+        }));
+
+      before(`create another resource`, () => spark.encryption.kms.createUnboundKeys({count: 1})
+        .then(([key]) => spark.encryption.kms.createResource({
+          key
+        }))
+        .then((k) => {
+          otherKro = k;
+        }));
+
+      before(`add auths to resource`, () => spark.encryption.kms.addAuthorization({
+        authIds: [otherKro.uri, anotherUser.spark.device.userId],
+        kro
+      })
+        .then(([kroAuth, userAuth]) => {
+          assert.equal(kroAuth.authId, otherKro.uri);
+          assert.equal(userAuth.authId, anotherUser.spark.device.userId);
+        }));
+
+      it(`deauthorizes a user from a key`, () => spark.encryption.kms.removeAuthorization({
+        userId: anotherUser.spark.device.userId,
+        kroUri: kro.uri
+      })
+        .then(([auth]) => {
+          assert.equal(auth.resourceUri, kro.uri);
+          assert.equal(auth.authId, anotherUser.spark.device.userId);
+        }));
+
+      it(`deauthorizes a resource from a key`, () => spark.encryption.kms.removeAuthorization({
+        authId: otherKro.uri,
+        kro
+      })
+        .then(([auth]) => {
+          assert.equal(auth.resourceUri, kro.uri);
+          assert.equal(auth.authId, otherKro.uri);
+        }));
     });
 
     describe(`#bindKey()`, () => {

--- a/packages/node_modules/@ciscospark/plugin-encryption/test/integration/spec/kms.js
+++ b/packages/node_modules/@ciscospark/plugin-encryption/test/integration/spec/kms.js
@@ -14,28 +14,27 @@ import uuid from 'uuid';
 describe(`Encryption`, function() {
   this.timeout(30000);
   describe(`KMS`, () => {
-    let spark, user;
-    let anotherUser;
+    let mccoy, spark, spock;
 
     before(`create test user`, () => testUsers.create({count: 2})
       .then((users) => {
-        user = users[0];
+        spock = users[0];
         spark = new CiscoSpark({
           credentials: {
-            authorization: user.token
+            authorization: spock.token
           }
         });
         assert.isTrue(spark.canAuthorize);
 
-        anotherUser = users[1];
-        anotherUser.spark = new CiscoSpark({
+        mccoy = users[1];
+        mccoy.spark = new CiscoSpark({
           credentials: {
-            authorization: anotherUser.token
+            authorization: mccoy.token
           }
         });
 
-        assert.isTrue(anotherUser.spark.canAuthorize);
-        return anotherUser.spark.device.register();
+        assert.isTrue(mccoy.spark.canAuthorize);
+        return mccoy.spark.device.register();
       }));
 
     after(() => spark && spark.mercury.disconnect());
@@ -57,23 +56,25 @@ describe(`Encryption`, function() {
     });
 
     describe(`#addAuthorization()`, () => {
-      let kro, otherKro;
+      let boundedKeyUri, kro, otherKro;
       before(`create a resource`, () => spark.encryption.kms.createUnboundKeys({count: 1})
         .then(([key]) => spark.encryption.kms.createResource({
           key
         }))
         .then((k) => {
           kro = k;
+          boundedKeyUri = kro.keyUris[0];
           assert.lengthOf(kro.authorizationUris, 1);
         }));
 
       it(`authorizes a user to a key`, () => spark.encryption.kms.addAuthorization({
-        userIds: [anotherUser.spark.device.userId],
+        userIds: [mccoy.spark.device.userId],
         kroUri: kro.uri
       })
         .then(([auth]) => {
           assert.equal(auth.resourceUri, kro.uri);
-          assert.equal(auth.authId, anotherUser.spark.device.userId);
+          assert.equal(auth.authId, mccoy.spark.device.userId);
+          return assert.isFulfilled(mccoy.spark.encryption.kms.fetchKey({uri: boundedKeyUri}));
         }));
 
       it(`authorizes a resource to a key`, () => spark.encryption.kms.createUnboundKeys({count: 1})
@@ -92,13 +93,14 @@ describe(`Encryption`, function() {
     });
 
     describe(`#removeAuthorization()`, () => {
-      let kro, otherKro;
+      let boundedKeyUri, kro, otherKro;
       before(`create resource`, () => spark.encryption.kms.createUnboundKeys({count: 1})
         .then(([key]) => spark.encryption.kms.createResource({
           key
         }))
         .then((k) => {
           kro = k;
+          boundedKeyUri = kro.keyUris[0];
           assert.lengthOf(kro.authorizationUris, 1);
         }));
 
@@ -111,21 +113,22 @@ describe(`Encryption`, function() {
         }));
 
       before(`add auths to resource`, () => spark.encryption.kms.addAuthorization({
-        authIds: [otherKro.uri, anotherUser.spark.device.userId],
+        authIds: [otherKro.uri, mccoy.spark.device.userId],
         kro
       })
         .then(([kroAuth, userAuth]) => {
           assert.equal(kroAuth.authId, otherKro.uri);
-          assert.equal(userAuth.authId, anotherUser.spark.device.userId);
+          assert.equal(userAuth.authId, mccoy.spark.device.userId);
         }));
 
       it(`deauthorizes a user from a key`, () => spark.encryption.kms.removeAuthorization({
-        userId: anotherUser.spark.device.userId,
+        userId: mccoy.spark.device.userId,
         kroUri: kro.uri
       })
         .then(([auth]) => {
           assert.equal(auth.resourceUri, kro.uri);
-          assert.equal(auth.authId, anotherUser.spark.device.userId);
+          assert.equal(auth.authId, mccoy.spark.device.userId);
+          return assert.isRejected(mccoy.spark.encryption.kms.fetchKey({uri: boundedKeyUri}));
         }));
 
       it(`deauthorizes a resource from a key`, () => spark.encryption.kms.removeAuthorization({
@@ -248,7 +251,7 @@ describe(`Encryption`, function() {
         .then((users) => {
           const fedUser = users[0];
           assert.equal(fedUser.orgId, `75dcf6c2-247d-4e3d-a32c-ff3ee28398eb`);
-          assert.notEqual(fedUser.orgId, user.orgId);
+          assert.notEqual(fedUser.orgId, spock.orgId);
 
           fedSpark = new CiscoSpark({
             credentials: {

--- a/test/integration/spec/services/board/actions.js
+++ b/test/integration/spec/services/board/actions.js
@@ -479,14 +479,8 @@ describe('Services', function() {
         });
 
         describe('when a user leaves conversation', function() {
-          it('does not allow board user to access contents', function() {
+          it('does not allow board user to create board', function() {
             var currentConvo;
-            var currentBoard;
-            var encryptedData = {};
-            var data = [{
-              type: 'curve',
-              payload: JSON.stringify({type: 'curve'})
-            }];
 
             return party.mccoy.spark.conversation.create({
               displayName: 'Test Board Member Leave Conversation',
@@ -494,24 +488,10 @@ describe('Services', function() {
             })
               .then(function(c) {
                 currentConvo = c;
-                return party.mccoy.spark.board.persistence.createChannel(currentConvo);
-              })
-              .then(function(b) {
-                currentBoard = b;
-                return party.spock.spark.board.encryptContents(currentBoard.defaultEncryptionKeyUrl, data);
-              })
-              .then(function(encryptedResult) {
-                encryptedData.items = encryptedResult;
                 return party.spock.spark.conversation.leave(currentConvo);
               })
               .then(function() {
-                return assert.isRejected(party.spock.spark.board.persistence.getAllContent(currentBoard));
-              })
-              .then(function() {
-                return party.spock.spark.encryption.keystore.clear();
-              })
-              .then(function() {
-                return assert.isRejected(party.spock.spark.board.decryptContents(encryptedData));
+                return assert.isRejected(party.spock.spark.board.persistence.createChannel(currentConvo));
               });
           });
 


### PR DESCRIPTION
Currently, KMS server also authorizes the resource creator, in this case it adds
the board creator to board KRO on `createChannel`, which we don't want. We want only
conversation KRO to be in the list of authorization. 
As a result, board creator can have access to board encryption key even after leaving the conversation.

This PR checks if the board creator is authorized, if so remove the auth.
KMS is making changes to this, however, we don't know when that happens.