### PR TITLE
robust close codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "lint-staged": "^3.3.0",
     "load-grunt-tasks": "^3.5.0",
     "lodash": "^4.13.1",
-    "lolex": "^1.5.1",
+    "lolex": "^1.6.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.5.3",
     "nue": "~0.7.0-dev",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,7 +25,7 @@
     "babel-register": "^6.4.3",
     "eslint": "^3.5.0",
     "eslint-plugin-mocha": "^4.5.1",
-    "lolex": "^1.4.0"
+    "lolex": "^1.6.0"
   },
   "engines": {
     "node": ">=4"

--- a/packages/plugin-board/test/unit/spec/realtime.js
+++ b/packages/plugin-board/test/unit/spec/realtime.js
@@ -6,7 +6,7 @@
 import {assert} from '@ciscospark/test-helper-chai';
 import MockSpark from '@ciscospark/test-helper-mock-spark';
 import MockSocket from '@ciscospark/test-helper-mock-socket';
-import {ConnectionError, AuthorizationError} from '@ciscospark/plugin-mercury';
+import {ConnectionError, NotAuthorized} from '@ciscospark/plugin-mercury';
 import sinon from '@ciscospark/test-helper-sinon';
 import Board, {config} from '../..';
 import uuid from 'uuid';
@@ -294,7 +294,7 @@ describe(`plugin-board`, () => {
 
       it(`rejects on AuthorizationError`, () => {
         spark.board.config.maxRetries = 1;
-        spark.credentials.getAuthorization.returns(Promise.reject(new AuthorizationError()));
+        spark.credentials.getAuthorization.returns(Promise.reject(new NotAuthorized()));
         return assert.isRejected(spark.board.realtime.connect());
       });
     });

--- a/packages/plugin-credentials/package.json
+++ b/packages/plugin-credentials/package.json
@@ -33,7 +33,7 @@
     "babel-polyfill": "^6.3.14",
     "babel-register": "^6.4.3",
     "eslint": "^3.5.0",
-    "lolex": "^1.5.1",
+    "lolex": "^1.6.0",
     "uuid": "^2.0.3"
   },
   "engines": {

--- a/packages/plugin-mercury/package.json
+++ b/packages/plugin-mercury/package.json
@@ -37,7 +37,7 @@
     "babel-register": "^6.4.3",
     "eslint": "^3.5.0",
     "eslint-plugin-mocha": "^4.5.1",
-    "lolex": "^1.4.0"
+    "lolex": "^1.6.0"
   },
   "engines": {
     "node": ">=4"

--- a/packages/plugin-mercury/package.json
+++ b/packages/plugin-mercury/package.json
@@ -20,7 +20,7 @@
     "lodash": "^4.13.1",
     "string": "^3.3.1",
     "uuid": "^2.0.1",
-    "ws": "^1.1.0"
+    "ws": "^2.2.2"
   },
   "devDependencies": {
     "@ciscospark/test-helper-chai": "^0.7.69",

--- a/packages/plugin-mercury/src/errors.js
+++ b/packages/plugin-mercury/src/errors.js
@@ -31,6 +31,13 @@ export class ConnectionError extends Exception {
 /**
  * thrown for CloseCode 4400
  */
+export class UnknownResponse extends ConnectionError {
+  static defaultMessage = `UnknownResponse is produced by IE when we receive a 4XXX. You probably want to treat this like a NotFound`;
+}
+
+/**
+ * thrown for CloseCode 4400
+ */
 export class BadRequest extends ConnectionError {
   static defaultMessage = `BadRequest usually implies an attempt to use service account credentials`;
 }

--- a/packages/plugin-mercury/src/errors.js
+++ b/packages/plugin-mercury/src/errors.js
@@ -9,6 +9,7 @@ import {Exception} from '@ciscospark/common';
  * Exception thrown when a websocket gets closed
  */
 export class ConnectionError extends Exception {
+  static defaultMessage = `Failed to connect to socket`;
   /**
    * @param {CloseEvent} event
    * @returns {string}
@@ -28,6 +29,29 @@ export class ConnectionError extends Exception {
 }
 
 /**
- * Exception thrown when a websocket gets closed for auth reasons
+ * thrown for CloseCode 4400
  */
-export class AuthorizationError extends ConnectionError {}
+export class BadRequest extends ConnectionError {
+  static defaultMessage = `BadRequest usually implies an attempt to use service account credentials`;
+}
+
+/**
+ * thrown for CloseCode 4401
+ */
+export class NotAuthorized extends ConnectionError {
+  static defaultMessage = `Please refresh your access token`
+}
+
+/**
+ * thrown for CloseCode 4403
+ */
+export class Forbidden extends ConnectionError {
+  static defaultMessage = `Forbidden usually implies these credentials are not entitled for Spark`;
+}
+
+// /**
+//  * thrown for CloseCode 4404
+//  */
+// export class NotFound extends ConnectionError {
+//   static defaultMessage = `Please refresh your Mercury registration (typically via a WDM refresh)`;
+// }

--- a/packages/plugin-mercury/src/index.js
+++ b/packages/plugin-mercury/src/index.js
@@ -18,4 +18,10 @@ export {default as default} from './mercury';
 export {default as Mercury} from './mercury';
 export {default as Socket} from './socket';
 export {default as config} from './config';
-export {AuthorizationError, ConnectionError} from './errors';
+export {
+  BadRequest,
+  ConnectionError,
+  Forbidden,
+  NotAuthorized
+  // NotFound
+} from './errors';

--- a/packages/plugin-mercury/src/mercury.js
+++ b/packages/plugin-mercury/src/mercury.js
@@ -10,7 +10,12 @@ import {set} from 'lodash';
 import S from 'string';
 import backoff from 'backoff';
 import Socket from './socket';
-import {AuthorizationError} from './errors';
+import {
+  BadRequest,
+  Forbidden,
+  NotAuthorized
+  // NotFound
+} from './errors';
 
 const normalReconnectReasons = [
   `idle`,
@@ -142,16 +147,29 @@ const Mercury = SparkPlugin.extend({
           this._emit(`connection_failed`, reason, {retries: this.backoffCall.getNumRetries()});
         }
         this.logger.info(`mercury: connection attempt failed`, reason);
-        if (reason instanceof AuthorizationError) {
+        // NotAuthorized implies expired token
+        if (reason instanceof NotAuthorized) {
           this.logger.info(`mercury: received authorization error, reauthorizing`);
-          return this.spark.refresh()
+          return this.spark.credentials.refresh({force: true})
             .then(() => callback(reason));
         }
-
+        // // NotFound implies expired web socket url
+        // else if (reason instanceof NotFound) {
+        //   this.logger.info(`mercury: received not found error, refreshing device registration`);
+        //   return this.spark.device.refresh()
+        //     .then(() => callback(reason));
+        // }
+        // BadRequest implies current credentials are for a Service Account
+        // Forbidden implies current user is not entitle for Spark
+        else if (reason instanceof BadRequest || reason instanceof Forbidden) {
+          this.logger.warn(`mercury: received unrecoverable response from mercury`);
+          this.backoffCall.abort();
+          return callback(reason);
+        }
         return callback(reason);
       })
       .catch((reason) => {
-        this.logger.error(`mercury: failed to handle connection failured`, reason);
+        this.logger.error(`mercury: failed to handle connection failure`, reason);
         callback(reason);
       });
   },

--- a/packages/plugin-mercury/test/integration/spec/mercury.js
+++ b/packages/plugin-mercury/test/integration/spec/mercury.js
@@ -9,6 +9,7 @@ import {assert} from '@ciscospark/test-helper-chai';
 import sinon from '@ciscospark/test-helper-sinon';
 import CiscoSpark from '@ciscospark/spark-core';
 import testUsers from '@ciscospark/test-helper-test-users';
+// import uuid from 'uuid';
 
 describe(`plugin-mercury`, function() {
   this.timeout(30000);
@@ -28,6 +29,31 @@ describe(`plugin-mercury`, function() {
 
     describe(`#connect()`, () => {
       it(`connects to mercury`, () => assert.isFulfilled(spark.mercury.connect()));
+
+      it(`refreshes the access token when a 4401 is received`, () => spark.device.register()
+        .then(() => {
+          // eslint-disable-next-line camelcase
+          spark.credentials.authorization.access_token = `fake token`;
+          return assert.isFulfilled(spark.mercury.connect());
+        })
+        // eslint-disable-next-line camelcase
+        .then(() => assert.notEqual(spark.credentials.authorization.access_token, `fake token`)));
+
+      // This doesn't work as designed yet. The only way to get a 4404 is to try
+      // to connect to someone else's valid registration; the intent was to get
+      // a 4404 any time we try to connect to an invalid url. Actually, as it's
+      // implemented, it should really be a 4403.
+      // it(`refreshes the device when a 4404 is received`, () => spark.device.register()
+      //   .then(() => {
+      //     const webSocketUrl = spark.device.webSocketUrl;
+      //     const wsu = spark.device.webSocketUrl.split(`/`);
+      //     wsu.reverse();
+      //     wsu[1] = uuid.v4();
+      //     wsu.reverse();
+      //     spark.device.webSocketUrl = wsu.join(`/`);
+      //     return spark.mercury.connect()
+      //       .then(() => assert.notEqual(spark.device.webSocketUrl, webSocketUrl));
+      //   }));
     });
 
     it(`emits messages that arrive before authorization completes`, () => {

--- a/packages/plugin-metrics/package.json
+++ b/packages/plugin-metrics/package.json
@@ -29,7 +29,7 @@
     "babel-register": "^6.4.3",
     "eslint": "^3.5.0",
     "eslint-plugin-mocha": "^4.5.1",
-    "lolex": "^1.5.1"
+    "lolex": "^1.6.0"
   },
   "engines": {
     "node": ">=4"

--- a/packages/plugin-wdm/package.json
+++ b/packages/plugin-wdm/package.json
@@ -30,7 +30,7 @@
     "babel-register": "^6.4.3",
     "eslint": "^3.5.0",
     "eslint-plugin-mocha": "^4.5.1",
-    "lolex": "^1.5.2"
+    "lolex": "^1.6.0"
   },
   "engines": {
     "node": ">=4"

--- a/packages/plugin-wdm/test/integration/spec/device.js
+++ b/packages/plugin-wdm/test/integration/spec/device.js
@@ -55,6 +55,18 @@ describe(`plugin-wdm`, function() {
             assert.equal(spark.device.url, url, `Refreshing the device without sending the entire original payload must not give us a new registration`);
           });
       });
+
+      it(`refreshes the device even if the device has expired`, () => {
+        const url = spark.device.url;
+        return spark.request({
+          url,
+          method: `DELETE`
+        })
+          .then(() => spark.device.refresh())
+          .then(() => {
+            assert.equal(spark.device.url, url);
+          });
+      });
     });
 
     describe(`#unregister()`, () => {

--- a/packages/spark-core/package.json
+++ b/packages/spark-core/package.json
@@ -36,7 +36,7 @@
     "babel-register": "^6.4.3",
     "eslint": "^3.5.0",
     "eslint-plugin-mocha": "^4.5.1",
-    "lolex": "^1.5.1"
+    "lolex": "^1.6.0"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
This puts us in position to easily add support for additional codes once we have a complete plan of action for how to handle multiple sockets

Note: commented-out code blocks are intentional; the NotFound close code doesn't quite work as intended, but the rest of these changes are still helpful without it.