### PR TITLE
Implement fetching meetings via calendar hybrid service

### DIFF
--- a/docker/builder/cmd.sh
+++ b/docker/builder/cmd.sh
@@ -59,7 +59,8 @@ for SUITE_ITERATION in $(seq 1 "${MAX_TEST_SUITE_RETRIES}"); do
 
       set +e
       daemon -U --name sauce_connect -- ${SC_BINARY} \
-        -D *.ciscospark.com,*.wbx2.com,*.webex.com*,storage101.dfw1.clouddrive.com \
+        -B mercury-connection-a.wbx2.com \
+        -t internal-testing-services.wbx2.com,127.0.0.1,localhost \
         -vv \
         -l "$(pwd)/reports/sauce/sauce_connect.$(echo ${PACKAGE} | awk -F '/' '{ print $NF }').${SC_ITERATION}.log" \
         --tunnel-identifier "${SC_TUNNEL_IDENTIFIER}" \

--- a/packages/node_modules/@ciscospark/bin-sauce-connect/src/start.js
+++ b/packages/node_modules/@ciscospark/bin-sauce-connect/src/start.js
@@ -79,11 +79,13 @@ function connect() {
     }, 1000);
 
     spawn(`sc/bin/sc`, [
-      `-D`, [
-        `*.ciscospark.com`,
-        `*.wbx2.com`,
-        `*.webex.com`,
-        `storage101.dfw1.clouddrive.com`
+      `-B`, [
+        `mercury-connection-a.wbx2.com`
+      ].join(`,`),
+      `-t`, [
+        `internal-testing-services.wbx2.com`,
+        `127.0.0.1`,
+        `localhost`
       ].join(`,`),
       `-vv`,
       `-l`, `${logFile}`,

--- a/packages/node_modules/@ciscospark/plugin-calendar/README.md
+++ b/packages/node_modules/@ciscospark/plugin-calendar/README.md
@@ -1,0 +1,3 @@
+# @ciscospark/plugin-calendar
+
+See https://ciscospark.github.io/spark-js-sdk/

--- a/packages/node_modules/@ciscospark/plugin-calendar/package.json
+++ b/packages/node_modules/@ciscospark/plugin-calendar/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@ciscospark/plugin-calendar",
+  "description": "",
+  "license": "MIT",
+  "author": "Uday Srinath <usrinath@cisco.com>",
+  "main": "dist/index.js",
+  "devMain": "src/index.js",
+  "repository": "https://github.com/ciscospark/spark-js-sdk/tree/master/packages/plugin-calendar",
+  "engines": {
+    "node": ">=4"
+  },
+  "browserify": {
+    "transform": [
+      "babelify",
+      "envify"
+    ]
+  }
+}

--- a/packages/node_modules/@ciscospark/plugin-calendar/src/calendar.js
+++ b/packages/node_modules/@ciscospark/plugin-calendar/src/calendar.js
@@ -1,0 +1,31 @@
+/**!
+ *
+ * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
+ * @private
+ */
+
+import {SparkPlugin} from '@ciscospark/spark-core';
+
+const Calendar = SparkPlugin.extend({
+  namespace: `Calendar`,
+
+  /**
+   * Retrieves a collection of meetings based on the request parameters
+   * @param {Object} options
+   * @param {Date} options.fromDate the start of the time range
+   * @param {Date} options.toDate the end of the time range
+   * @returns {Promise} Resolves with an array of meetings
+   */
+  list(options) {
+    options = options || {};
+    return this.spark.request({
+      method: `GET`,
+      service: `calendar`,
+      resource: `calendarEvents`,
+      qs: options
+    })
+      .then((res) => res.body.items);
+  }
+});
+
+export default Calendar;

--- a/packages/node_modules/@ciscospark/plugin-calendar/src/config.js
+++ b/packages/node_modules/@ciscospark/plugin-calendar/src/config.js
@@ -1,0 +1,9 @@
+/**!
+ *
+ * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
+ * @private
+ */
+
+export default {
+  calendar: {}
+};

--- a/packages/node_modules/@ciscospark/plugin-calendar/src/index.js
+++ b/packages/node_modules/@ciscospark/plugin-calendar/src/index.js
@@ -1,0 +1,71 @@
+/**!
+ *
+ * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
+ * @private
+ */
+
+import '@ciscospark/plugin-wdm';
+import '@ciscospark/plugin-encryption';
+import '@ciscospark/plugin-conversation';
+
+import {registerPlugin} from '@ciscospark/spark-core';
+import Calendar from './calendar';
+import config from './config';
+import {has} from 'lodash';
+
+registerPlugin(`calendar`, Calendar, {
+  config,
+  payloadTransformer: {
+    predicates: [
+      {
+        name: `transformMeetingArray`,
+        direction: `inbound`,
+        test(ctx, response) {
+          return Promise.resolve(has(response, `body.items[0].seriesId`));
+        },
+        extract(response) {
+          return Promise.resolve(response.body.items);
+        }
+      },
+      {
+        name: `transformMeeting`,
+        direction: `inbound`,
+        test(ctx, response) {
+          return Promise.resolve(has(response, `body.seriesId`));
+        },
+        extract(response) {
+          return Promise.resolve(response.body);
+        }
+      }
+    ],
+    transforms: [
+      {
+        name: `transformMeetingArray`,
+        fn(ctx, array) {
+          return Promise.all(array.map((item) => ctx.transform(`transformMeeting`, item)));
+        }
+      },
+      {
+        name: `transformMeeting`,
+        direction: `inbound`,
+        fn(ctx, object) {
+          if (!object) {
+            return Promise.resolve();
+          }
+
+          if (!object.encryptionKeyUrl) {
+            return Promise.resolve();
+          }
+
+          return Promise.all([
+            ctx.transform(`decryptTextProp`, `encryptedSubject`, object.encryptionKeyUrl, object),
+            ctx.transform(`decryptTextProp`, `encryptedLocation`, object.encryptionKeyUrl, object),
+            ctx.transform(`decryptTextProp`, `encryptedNotes`, object.encryptionKeyUrl, object)
+          ]);
+        }
+      }
+    ]
+  }
+});
+
+export {default as default} from './calendar';

--- a/packages/node_modules/@ciscospark/plugin-calendar/test/.eslintrc.yml
+++ b/packages/node_modules/@ciscospark/plugin-calendar/test/.eslintrc.yml
@@ -1,0 +1,1 @@
+extends: "@ciscospark/eslint-config/mocha"

--- a/packages/node_modules/@ciscospark/plugin-calendar/test/index.js
+++ b/packages/node_modules/@ciscospark/plugin-calendar/test/index.js
@@ -1,0 +1,28 @@
+/**!
+ *
+ * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
+ * @private
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/* istanbul ignore else */
+if (!global._babelPolyfill) {
+  require('babel-polyfill');
+}
+
+// helper file for code coverage
+if (process.env.COVERAGE && (new RegExp(process.env.PACKAGE + '$')).test(require('../package').name)) {
+  if (typeof window === 'undefined') {
+    var covered = '../.coverage/src';
+    module.exports = require(covered);
+  }
+  else {
+    module.exports = require('../src');
+  }
+}
+else {
+  module.exports = require('..');
+}

--- a/packages/node_modules/@ciscospark/plugin-calendar/test/integration/spec/calendar.js
+++ b/packages/node_modules/@ciscospark/plugin-calendar/test/integration/spec/calendar.js
@@ -1,0 +1,177 @@
+/**!
+ *
+ * Copyright (c) 2015-2016 Cisco Systems, Inc. See LICENSE file.
+ */
+
+ /* eslint camelcase: [0] */
+
+import '../..';
+import CiscoSpark from '@ciscospark/spark-core';
+import {assert} from '@ciscospark/test-helper-chai';
+import testUsers from '@ciscospark/test-helper-test-users';
+import uuid from 'uuid';
+import {merge} from 'lodash';
+
+
+/**
+ * produces a mock meeting object
+ * @param {Object} params
+ * @returns {Meeting}
+ */
+function makeMockMeeting(params) {
+  params = params || {};
+  return merge({
+    changeType: params.changeType,
+    userId: params.organizer.emailAddress,
+    userUUID: params.organizer.id,
+    emailAddress: params.organizer.emailAddress,
+    itemId: `ItemId-${params.meetingId}`,
+    meeting: {
+      body: params.body,
+      callUri: `https://locus-example.com/locus/api/v1/loci/${params.locusId}`,
+      encryptionV2: true,
+      endDate: params.end,
+      featureTogglesMap: [
+        {
+          calsvc_calendar_view: true
+        }
+      ],
+      hasAttachments: params.hasAttachments,
+      iCalUid: params.meetingId,
+      isRecurring: params.isRecurring,
+      isReminderSet: params.isReminderSet,
+      itemId: `ItemId-${params.meetingId}`,
+      location: params.location,
+      mailboxAttendeesInMeeting: [
+        params.participants.participant1.emailAddress,
+        params.participants.participant2.emailAddress
+      ],
+      mailboxInviteesInMeeting: [
+        {
+          id: params.participants.participant1.id,
+          invitee: params.participants.participant1.emailAddress,
+          type: `PERSON`,
+          responseType: `NO_RESPONSE`,
+          participantType: `OPTIONAL`
+        },
+        {
+          id: params.participants.participant2.id,
+          invitee: params.participants.participant2.emailAddress,
+          type: `PERSON`,
+          responseType: `UNKNOWN_RESPONSE`,
+          participantType: `REQUIRED`
+        }
+      ],
+      meetingIdentifier: {
+        id: `MeetingId-${params.meetingId}`
+      },
+      meetingTime: params.start,
+      organizer: params.organizer.emailAddress,
+      startDate: params.start,
+      subject: params.title
+    },
+    meetingIdentifier: {
+      id: `MeetingId-${params.meetingId}`
+    }
+  }, params);
+}
+
+describe(`plugin-calendar`, () => {
+  describe(`#list()`, () => {
+    let createdMeeting, creator, mccoy, meetingParams, spark, spock;
+
+    before(`create test users`, () => testUsers.create({
+      count: 3,
+      config: {
+        entitlements: [
+          `spark`,
+          `squaredCallInitiation`,
+          `squaredInviter`,
+          `squaredRoomModeration`,
+          `webExSquared`,
+          `squaredFusionCal`
+        ]
+      }
+    })
+      .then((users) => {
+        [creator, spock, mccoy] = users;
+
+        spark = new CiscoSpark({
+          credentials: {
+            authorization: creator.token
+          },
+          config: {
+            device: {
+              preDiscoveryServices: {
+                whistlerServiceUrl: process.env.WHISTLER_API_SERVICE_URL || `http://internal-testing-services.wbx2.com:8084/api/v1`
+              }
+            }
+          }
+        });
+      }));
+
+    const hour = 1000 * 60 * 60;
+    const startInterval = new Date(new Date().getTime() + hour * 2).toISOString();
+    const endInterval = new Date(new Date(startInterval).getTime() + hour).toISOString();
+    const meetingID = uuid.v4();
+    const locusID = uuid.v4();
+
+    before(`creates a meeting`, () => {
+      meetingParams = {
+        changeType: `CREATE`,
+        meetingId: meetingID,
+        start: startInterval,
+        end: endInterval,
+        title: `test-plugin-calendar-meeting-${meetingID}`,
+        locusId: locusID,
+        hasAttachments: false,
+        isRecurring: false,
+        isReminderSet: false,
+        organizer: creator,
+        participants: {
+          participant1: mccoy,
+          participant2: spock
+        },
+        location: `@spark`,
+        body: `Test Agenda`
+      };
+
+      return spark.request({
+        method: `POST`,
+        service: `whistler`,
+        resource: `calendarNotification`,
+        body: makeMockMeeting(meetingParams),
+        qs: {
+          isinteg: false
+        }
+      })
+        .then((res) => {
+          createdMeeting = res.body;
+          assert.isDefined(createdMeeting);
+          assert.equal(createdMeeting.meeting.meetingIdentifier.id, `MeetingId-${meetingID}`);
+          assert.equal(createdMeeting.userUUID, meetingParams.organizer.id);
+          assert.equal(createdMeeting.meeting.startDate, meetingParams.start);
+          assert.equal(createdMeeting.meeting.endDate, meetingParams.end);
+        });
+    });
+
+    beforeEach(`registers to wdm`, () => spark.device.register());
+
+    it(`retrieves the meeting list for default date range`, () => spark.calendar.list()
+      .then((meetings) => {
+        assert.equal(createdMeeting.meeting.icalUid, meetings[0].seriesId);
+        assert.equal(createdMeeting.userUUID, meetings[0].organizer);
+        assert.equal(createdMeeting.meeting.startDate, meetings[0].start);
+        assert.equal(Math.round((new Date(createdMeeting.meeting.endDate).getTime() - new Date(createdMeeting.meeting.startDate).getTime()) / 60000), meetings[0].durationMinutes);
+
+        // Validate decryption of subject, location and agenda
+        assert.isDefined(meetings[0].encryptedSubject);
+        assert.equal(meetingParams.title, meetings[0].encryptedSubject);
+        assert.isDefined(meetings[0].encryptedLocation);
+        assert.equal(meetingParams.location, meetings[0].encryptedLocation);
+        assert.isDefined(meetings[0].encryptedNotes);
+        assert.equal(meetingParams.body, meetings[0].encryptedNotes);
+
+      }));
+  });
+});


### PR DESCRIPTION
This is just a small update to Uday's approved PR https://github.com/ciscospark/spark-js-sdk/pull/383  to add a bump parameter to sauce connect in order for tests to run on Sauce via tunneling. Also updated code to work on latest sdk master.

@ianwremmel Please Review

There's some WIP work for updating this to use the new Whistler endpoint, but that's being blocked by a decryption bug in Calendar. Will add that to another PR when that is fixed.