### PR TITLE
test(plugin-board): create new conversation for channel listing test

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/test/integration/spec/board.js
@@ -179,44 +179,54 @@ describe(`plugin-board`, () => {
       });
 
       it(`retrieves all boards for a specified conversation across multiple pages`, () => {
-        let existingChannelsCount = 0;
-        let numChannelsToAdd = 0;
-        const pageLimit = 50;
+        const numChannelsToAdd = 12;
+        const pageLimit = 5;
+        const channelsCreated = [];
+        let channelsReceived = [];
+        let convo;
 
-        return participants[0].spark.board.getChannels(conversation, {
-          channelsLimit: 100
+        return participants[0].spark.conversation.create({
+          displayName: `Test Get Channels Conversation ${uuid.v4()}`,
+          participants
         })
-          .then((res) => {
-            existingChannelsCount = res.length;
-            assert(existingChannelsCount < pageLimit, `the existing channel count must be less that pageLimit for this test`);
-            numChannelsToAdd = pageLimit - existingChannelsCount + 1;
-          })
-
-          .then(() => {
+          .then((c) => {
+            convo = c;
             const promises = [];
 
             for (let i = 0; i < numChannelsToAdd; i++) {
-              promises.push(participants[0].spark.board.createChannel(conversation));
+              promises.push(participants[0].spark.board.createChannel(convo)
+                .then((channel) => {
+                  Reflect.deleteProperty(channel, `kmsMessage`);
+                  channelsCreated.push(channel);
+                }));
             }
             return Promise.all(promises);
           })
-
           // get boards, page 1
           .then(() => {
-            return participants[0].spark.board.getChannels(conversation, {
+            return participants[0].spark.board.getChannels(convo, {
               channelsLimit: pageLimit
             });
           })
-
           // get boards, page 2
           .then((channelPage) => {
             assert.lengthOf(channelPage.items, pageLimit);
             assert(channelPage.hasNext());
+            channelsReceived = channelsReceived.concat(channelPage.items);
+            return channelPage.next();
+          })
+          // get boards, page 3
+          .then((channelPage) => {
+            assert.lengthOf(channelPage.items, pageLimit);
+            assert(channelPage.hasNext());
+            channelsReceived = channelsReceived.concat(channelPage.items);
             return channelPage.next();
           })
           .then((channelPage) => {
-            assert.lengthOf(channelPage, 1);
+            assert.lengthOf(channelPage, 2);
             assert(!channelPage.hasNext());
+            channelsReceived = channelsReceived.concat(channelPage.items);
+            assert.sameDeepMembers(channelsCreated, channelsReceived);
           });
       });
     });

--- a/packages/node_modules/@ciscospark/plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/plugin-board/test/integration/spec/board.js
@@ -94,7 +94,7 @@ describe(`plugin-board`, () => {
       it(`uploads image to spark files`, () => {
         return participants[0].spark.board._uploadImage(board, fixture)
           .then((scr) => participants[1].spark.encryption.download(scr))
-          .then((downloadedFile) => assert(fh.isMatchingFile(downloadedFile, fixture)));
+          .then((downloadedFile) => assert.becomes(fh.isMatchingFile(downloadedFile, fixture), true));
       });
     });
 
@@ -118,7 +118,7 @@ describe(`plugin-board`, () => {
             return participants[2].spark.encryption.decryptScr(board.defaultEncryptionKeyUrl, res.image.scr);
           })
           .then((decryptedScr) => participants[2].spark.encryption.download(decryptedScr))
-          .then((file) => assert(fh.isMatchingFile(file, fixture)));
+          .then((file) => assert.becomes(fh.isMatchingFile(file, fixture), true));
       });
     });
 
@@ -158,12 +158,12 @@ describe(`plugin-board`, () => {
 
       it(`matches file file downloaded`, () => {
         return participants[0].spark.encryption.download(testScr)
-          .then((downloadedFile) => assert(fh.isMatchingFile(downloadedFile, fixture)));
+          .then((downloadedFile) => assert.becomes(fh.isMatchingFile(downloadedFile, fixture), true));
       });
 
       it(`allows others to download image`, () => {
         return participants[2].spark.encryption.download(testScr)
-          .then((downloadedFile) => assert(fh.isMatchingFile(downloadedFile, fixture)));
+          .then((downloadedFile) => assert.becomes(fh.isMatchingFile(downloadedFile, fixture), true));
       });
     });
 
@@ -211,20 +211,20 @@ describe(`plugin-board`, () => {
           // get boards, page 2
           .then((channelPage) => {
             assert.lengthOf(channelPage.items, pageLimit);
-            assert(channelPage.hasNext());
+            assert.isTrue(channelPage.hasNext());
             channelsReceived = channelsReceived.concat(channelPage.items);
             return channelPage.next();
           })
           // get boards, page 3
           .then((channelPage) => {
             assert.lengthOf(channelPage.items, pageLimit);
-            assert(channelPage.hasNext());
+            assert.isTrue(channelPage.hasNext());
             channelsReceived = channelsReceived.concat(channelPage.items);
             return channelPage.next();
           })
           .then((channelPage) => {
             assert.lengthOf(channelPage, 2);
-            assert(!channelPage.hasNext());
+            assert.isFalse(channelPage.hasNext());
             channelsReceived = channelsReceived.concat(channelPage.items);
             assert.sameDeepMembers(channelsCreated, channelsReceived);
           });
@@ -304,7 +304,7 @@ describe(`plugin-board`, () => {
         it(`using the default page limit`, () => participants[0].spark.board.getContents(board)
           .then((res) => {
             assert.lengthOf(res, numberOfContents);
-            assert(!res.hasNext());
+            assert.isFalse(res.hasNext());
 
             for (let i = 0; i < res.length; i++) {
               assert.equal(res.items[i].payload, tonsOfContents[i].payload, `payload data matches`);
@@ -314,12 +314,12 @@ describe(`plugin-board`, () => {
         it(`using a client defined page limit`, () => participants[0].spark.board.getContents(board, {contentsLimit: 25})
           .then((res) => {
             assert.lengthOf(res, 25);
-            assert(res.hasNext());
+            assert.isTrue(res.hasNext());
             return res.next();
           })
           .then((res) => {
             assert.lengthOf(res, numberOfContents - 25);
-            assert(!res.hasNext());
+            assert.isFalse(res.hasNext());
           }));
       });
     });


### PR DESCRIPTION
Sometimes karma runs test multiple times on the same browser in
parallel, which creates more channels than expected for one
conversation. This change should protect these tests from mentioned race
condition.

