### PR TITLE
Sdkv7 avatar

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-batcher.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-batcher.js
@@ -53,6 +53,9 @@ const AvatarUrlBatcher = Batcher.extend({
   },
 
   handleItemSuccess(item) {
+    const maxAge = item.response.cacheControl && item.response.cacheControl.indexOf(`max-age=`) !== -1 && Number(item.response.cacheControl.split(`max-age=`)[1]) || undefined;
+    item = {uuid: item.uuid, size: item.size, url: item.response.url, maxAge};
+
     return this.getDeferredForResponse(item)
       .then((defer) => defer.resolve(item));
   },

--- a/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-batcher.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-batcher.js
@@ -15,7 +15,10 @@ const AvatarUrlBatcher = Batcher.extend({
     return Promise.all(res.options.body.map((req) => {
       return Promise.all(req.sizes.map((size) => {
         const response = res.body[req.uuid] && res.body[req.uuid][size] || undefined;
-        return this.acceptItem({uuid: req.uuid, size, response});
+        return this.acceptItem({
+          response,
+          uuid: req.uuid,
+          size});
       }));
     }));
   },
@@ -53,11 +56,11 @@ const AvatarUrlBatcher = Batcher.extend({
   },
 
   handleItemSuccess(item) {
-    const maxAge = item.response.cacheControl && item.response.cacheControl.indexOf(`max-age=`) !== -1 && Number(item.response.cacheControl.split(`max-age=`)[1]) || undefined;
-    item = {uuid: item.uuid, size: item.size, url: item.response.url, maxAge};
-
     return this.getDeferredForResponse(item)
-      .then((defer) => defer.resolve(item));
+      .then((defer) => defer.resolve({
+        uuid: item.uuid,
+        size: item.size,
+        url: item.response.url}));
   },
 
   fingerprintRequest(item) {

--- a/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-store.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-store.js
@@ -56,11 +56,11 @@ export default class AvatarUrlStore {
   /**
    * Adds the given item to the store
    * @param {Object} item
-   * @param {integer} cacheControl
+   * @param {integer} item.maxAge
    * @param {integer} item.size
    * @param {string} item.url
    * @param {string} item.uuid
-   * @returns {Promise<string>}
+   * @returns {Promise<string>} The URL of the added avatar
    */
   add(item) {
     if (!item) {
@@ -78,14 +78,13 @@ export default class AvatarUrlStore {
     if (!item.url) {
       return Promise.reject(new Error(`\`item.url\` is required`));
     }
-    if (!item.cacheControl) {
-      return Promise.reject(new Error(`\`item.cacheControl\` is required`));
+    if (!item.maxAge) {
+      return Promise.reject(new Error(`\`item.maxAge\` is required`));
     }
 
-    // use item suggested cache TTL or configed default if missing
-    setTimeout(this.remove.bind(this, item), item.cacheControl * 1000);
+    setTimeout(this.remove.bind(this, item), item.maxAge * 1000);
     urlByUuid.get(this).set(`${item.uuid} - ${item.size}`, item);
-    return Promise.resolve(item);
+    return Promise.resolve(item.url);
   }
 
   /**
@@ -98,8 +97,7 @@ export default class AvatarUrlStore {
    * @returns {Promise<true>}
    */
   remove(item) {
-    /* eslint no-extra-parens: [0] */
-    const sizes = (item.size && [item.size]) || [40, 50, 80, 110, 135, 192, 640, 1600];
+    const sizes = item.size && [item.size] || [40, 50, 80, 110, 135, 192, 640, 1600];
     sizes.forEach((one) => urlByUuid.get(this).delete(`${item.uuid} - ${one}`));
     return Promise.resolve(true);
   }

--- a/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-store.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-store.js
@@ -28,7 +28,7 @@ export default class AvatarUrlStore {
    * @param {object} item
    * @param {string} item.uuid A user uuid
    * @param {integer}item.size the requested size
-   * @returns {Promise<object> Resolves to the avatar item {uuid, url, size, cacheControl}
+   * @returns {Promise<object>} Resolves to the avatar item {uuid, url, size, cacheControl}
    *                           or Rejects on bad param, not in store
    *
    * @memberOf AvatarUrlStore

--- a/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-store.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/avatar-url-store.js
@@ -28,7 +28,8 @@ export default class AvatarUrlStore {
    * @param {object} item
    * @param {string} item.uuid A user uuid
    * @param {integer}item.size the requested size
-   * @returns {Promise} resolves to the URL or rejects if not mapped
+   * @returns {Promise<object> Resolves to the avatar item {uuid, url, size, cacheControl}
+   *                           or Rejects on bad param, not in store
    *
    * @memberOf AvatarUrlStore
    */
@@ -45,22 +46,21 @@ export default class AvatarUrlStore {
     if (!patterns.uuid.test(item.uuid)) {
       return Promise.reject(new Error(`\`item.uuid\` does not appear to be a uuid`));
     }
-
     const ret = urlByUuid.get(this).get(`${item.uuid} - ${item.size}`);
     if (ret) {
-      return Promise.resolve(ret.url);
+      return Promise.resolve(ret);
     }
-    return Promise.reject(new Error(`No URL found by specified id`));
+    return Promise.reject(new Error(`No URL found by specified id: ${JSON.stringify(item)}`));
   }
 
   /**
    * Adds the given item to the store
    * @param {Object} item
-   * @param {integer} item.maxAge
+   * @param {integer} item.cacheControl
    * @param {integer} item.size
    * @param {string} item.url
    * @param {string} item.uuid
-   * @returns {Promise<string>} The URL of the added avatar
+   * @returns {Promise<object>} Resolves to the added avatar item or rejects on bad params
    */
   add(item) {
     if (!item) {
@@ -78,13 +78,13 @@ export default class AvatarUrlStore {
     if (!item.url) {
       return Promise.reject(new Error(`\`item.url\` is required`));
     }
-    if (!item.maxAge) {
-      return Promise.reject(new Error(`\`item.maxAge\` is required`));
+    if (!item.cacheControl) {
+      return Promise.reject(new Error(`\`item.cacheControl\` is required`));
     }
 
-    setTimeout(this.remove.bind(this, item), item.maxAge * 1000);
+    setTimeout(this.remove.bind(this, item), item.cacheControl * 1000);
     urlByUuid.get(this).set(`${item.uuid} - ${item.size}`, item);
-    return Promise.resolve(item.url);
+    return Promise.resolve(item);
   }
 
   /**

--- a/packages/node_modules/@ciscospark/plugin-avatar/src/avatar.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/avatar.js
@@ -32,12 +32,12 @@ const Avatar = SparkPlugin.extend({
    * @param {Object} options
    * @param {integer} options.size
    * @param {integer} options.cacheControl
-   * @returns {Promise<Object>}
+   * @returns {Promise<string>} the avatar URL
    */
   _fetchAvatarUrl(uuid, options) {
-    return this.store.get(uuid, options.size)
-      .catch(() => this.batcher.request(Object.assign({}, {uuid, size: options.size}))
-        .then((item) => this.store.add(defaults(item, {cacheControl: options.cacheControl, url: item.response.url}))));
+    return this.store.get({uuid, size: options.size})
+      .catch(() => this.batcher.request({uuid, size: options.size, maxAge: options.maxAge})
+        .then((item) => this.store.add(item)));
   },
 
   /**
@@ -55,13 +55,11 @@ const Avatar = SparkPlugin.extend({
     }
 
     options = defaults(options, {
-      size: this.config.defaultAvatarSize,
-      cacheControl: this.config.cacheExpiration
+      size: this.config.defaultAvatarSize
     });
 
     return this.spark.user.asUUID(user)
-      .then((uuid) => this._fetchAvatarUrl(uuid, options)
-      .then((res) => res.url));
+      .then((uuid) => this._fetchAvatarUrl(uuid, options));
   },
 
   /**
@@ -96,7 +94,7 @@ const Avatar = SparkPlugin.extend({
     })
       .then((res) => {
         // invalidate user's cached avatar
-        this.store.remove(this.spark.device.userId);
+        this.store.remove({uuid: this.spark.device.userId});
         return res.url;
       });
   }

--- a/packages/node_modules/@ciscospark/plugin-avatar/src/avatar.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/avatar.js
@@ -36,7 +36,7 @@ const Avatar = SparkPlugin.extend({
    */
   _fetchAvatarUrl(uuid, options) {
     return this.store.get({uuid, size: options.size})
-      .catch(() => this.batcher.request({uuid, size: options.size, maxAge: options.maxAge})
+      .catch(() => this.batcher.request({uuid, size: options.size})
         .then((item) => this.store.add(item)));
   },
 

--- a/packages/node_modules/@ciscospark/plugin-avatar/src/avatar.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/avatar.js
@@ -36,8 +36,8 @@ const Avatar = SparkPlugin.extend({
    */
   _fetchAvatarUrl(uuid, options) {
     return this.store.get({uuid, size: options.size})
-      .catch(() => this.batcher.request({uuid, size: options.size})
-        .then((item) => this.store.add(item)));
+      .catch(() => this.batcher.request({uuid, size: options.size}))
+        .then((item) => this.store.add(defaults({cacheControl: options.cacheControl}, item)));
   },
 
   /**
@@ -55,11 +55,13 @@ const Avatar = SparkPlugin.extend({
     }
 
     options = defaults(options, {
+      cacheControl: this.config.cacheControl,
       size: this.config.defaultAvatarSize
     });
 
     return this.spark.user.asUUID(user)
-      .then((uuid) => this._fetchAvatarUrl(uuid, options));
+      .then((uuid) => this._fetchAvatarUrl(uuid, options))
+      .then((item) => item.url);
   },
 
   /**

--- a/packages/node_modules/@ciscospark/plugin-avatar/src/config.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/config.js
@@ -11,6 +11,11 @@ export default {
     batcherMaxWait: 1500,
 
     /**
+     * @description avatar URL store TTL, allows avatar updates to eventually be propegated
+     * @type {number} Number of seconds the avatar should remain in store
+     */
+    cacheControl: 60 * 60,
+    /**
      * @description default avatar size to retrieve if no size is specified
      * @type {number}
      */

--- a/packages/node_modules/@ciscospark/plugin-avatar/src/config.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/src/config.js
@@ -11,11 +11,6 @@ export default {
     batcherMaxWait: 1500,
 
     /**
-     * @description Milliseconds a cached avatar url is considered valid
-     * @type {number}
-     */
-    cacheExpiration: 60 * 60 * 1000,
-    /**
      * @description default avatar size to retrieve if no size is specified
      * @type {number}
      */

--- a/packages/node_modules/@ciscospark/plugin-avatar/test/integration/spec/avatar.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/test/integration/spec/avatar.js
@@ -55,7 +55,7 @@ describe(`plugin-avatar`, () => {
     it(`invalidates current user\`s cached avatar after uploading a new one`, () => {
       spark.avatar.store.remove = sinon.spy();
       return spark.avatar.setAvatar(sampleImageSmallOnePng)
-        .then(() => assert.calledWith(spark.avatar.store.remove, spark.device.userId));
+        .then(() => assert.calledWith(spark.avatar.store.remove, {uuid: spark.device.userId}));
     });
   });
 

--- a/packages/node_modules/@ciscospark/plugin-avatar/test/unit/spec/avatar-url-store.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/test/unit/spec/avatar-url-store.js
@@ -8,15 +8,15 @@ import MockSpark from '@ciscospark/test-helper-mock-spark';
 
 /* eslint camelcase: 0*/
 describe(`plugin-avatar`, () => {
-  const item1_40 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 40, url: `http://www-40.example.com`, maxAge: 300};
-  const item1_50 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 50, url: `http://www-50.example.com`, maxAge: 300};
-  const item1_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www-80.example.com`, maxAge: 300};
-  const item1_110 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 110, url: `http://www-110.example.com`, maxAge: 300};
-  const item1_192 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 192, url: `http://www-192.example.com`, maxAge: 300};
-  const item1_640 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 640, url: `http://www-640.example.com`, maxAge: 300};
-  const item1_1600 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 1600, url: `http://www-1600.example.com`, maxAge: 300};
-  const item2_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`, size: 80, url: `http://www2.example.com`, maxAge: 300};
-  const item3_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa2`, size: 80, url: `http://www3.example.com`, maxAge: 300};
+  const item1_40 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 40, url: `http://www-40.example.com`, cacheControl: 300};
+  const item1_50 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 50, url: `http://www-50.example.com`, cacheControl: 300};
+  const item1_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www-80.example.com`, cacheControl: 300};
+  const item1_110 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 110, url: `http://www-110.example.com`, cacheControl: 300};
+  const item1_192 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 192, url: `http://www-192.example.com`, cacheControl: 300};
+  const item1_640 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 640, url: `http://www-640.example.com`, cacheControl: 300};
+  const item1_1600 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 1600, url: `http://www-1600.example.com`, cacheControl: 300};
+  const item2_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`, size: 80, url: `http://www2.example.com`, cacheControl: 300};
+  const item3_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa2`, size: 80, url: `http://www3.example.com`, cacheControl: 300};
 
   describe(`AvatarUrlStore`, () => {
     let store;
@@ -37,8 +37,8 @@ describe(`plugin-avatar`, () => {
       assert.isRejected(store.add({uuid: `id1`}), `\`size\` is required`),
       assert.isRejected(store.add({uuid: `id1`, size: 80}), `\`uuid\` does not appear to be a uuid`),
       assert.isRejected(store.add({uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80}), `\`url\` is required`),
-      assert.isRejected(store.add({uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www.example.com`}), `\`maxAge\` is required`),
-      assert.isRejected(store.add({uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www.example.com`, maxAge: 0}), `\`maxAge\` is required`)
+      assert.isRejected(store.add({uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www.example.com`}), `\`cacheControl\` is required`),
+      assert.isRejected(store.add({uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www.example.com`, cacheControl: 0}), `\`cacheControl\` is required`)
     ]));
 
     it(`get item failures`, () => Promise.all([
@@ -53,9 +53,9 @@ describe(`plugin-avatar`, () => {
       assert.isFulfilled(store.add(item1_80)),
       assert.isFulfilled(store.add(item2_80)),
       assert.isFulfilled(store.add(item3_80)),
-      assert.eventually.deepEqual(store.get(item1_80), item1_80.url),
-      assert.eventually.deepEqual(store.get(item2_80), item2_80.url),
-      assert.eventually.deepEqual(store.get(item3_80), item3_80.url),
+      assert.eventually.deepEqual(store.get(item1_80), item1_80),
+      assert.eventually.deepEqual(store.get(item2_80), item2_80),
+      assert.eventually.deepEqual(store.get(item3_80), item3_80),
       store.remove(item2_80),
       store.remove(item3_80),
       assert.isRejected(store.get(item3_80)),

--- a/packages/node_modules/@ciscospark/plugin-avatar/test/unit/spec/avatar-url-store.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/test/unit/spec/avatar-url-store.js
@@ -8,15 +8,15 @@ import MockSpark from '@ciscospark/test-helper-mock-spark';
 
 /* eslint camelcase: 0*/
 describe(`plugin-avatar`, () => {
-  const item1_40 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 40, url: `http://www-40.example.com`, cacheControl: 300};
-  const item1_50 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 50, url: `http://www-50.example.com`, cacheControl: 300};
-  const item1_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www-80.example.com`, cacheControl: 300};
-  const item1_110 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 110, url: `http://www-110.example.com`, cacheControl: 300};
-  const item1_192 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 192, url: `http://www-192.example.com`, cacheControl: 300};
-  const item1_640 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 640, url: `http://www-640.example.com`, cacheControl: 300};
-  const item1_1600 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 1600, url: `http://www-1600.example.com`, cacheControl: 300};
-  const item2_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`, size: 80, url: `http://www2.example.com`, cacheControl: 300};
-  const item3_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa2`, size: 80, url: `http://www3.example.com`, cacheControl: 300};
+  const item1_40 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 40, url: `http://www-40.example.com`, maxAge: 300};
+  const item1_50 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 50, url: `http://www-50.example.com`, maxAge: 300};
+  const item1_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www-80.example.com`, maxAge: 300};
+  const item1_110 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 110, url: `http://www-110.example.com`, maxAge: 300};
+  const item1_192 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 192, url: `http://www-192.example.com`, maxAge: 300};
+  const item1_640 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 640, url: `http://www-640.example.com`, maxAge: 300};
+  const item1_1600 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 1600, url: `http://www-1600.example.com`, maxAge: 300};
+  const item2_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`, size: 80, url: `http://www2.example.com`, maxAge: 300};
+  const item3_80 = {uuid: `88888888-4444-4444-4444-aaaaaaaaaaa2`, size: 80, url: `http://www3.example.com`, maxAge: 300};
 
   describe(`AvatarUrlStore`, () => {
     let store;
@@ -37,7 +37,8 @@ describe(`plugin-avatar`, () => {
       assert.isRejected(store.add({uuid: `id1`}), `\`size\` is required`),
       assert.isRejected(store.add({uuid: `id1`, size: 80}), `\`uuid\` does not appear to be a uuid`),
       assert.isRejected(store.add({uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80}), `\`url\` is required`),
-      assert.isRejected(store.add({uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www.example.com`}), `\`cacheControl\` is required`)
+      assert.isRejected(store.add({uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www.example.com`}), `\`maxAge\` is required`),
+      assert.isRejected(store.add({uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`, size: 80, url: `http://www.example.com`, maxAge: 0}), `\`maxAge\` is required`)
     ]));
 
     it(`get item failures`, () => Promise.all([

--- a/packages/node_modules/@ciscospark/plugin-avatar/test/unit/spec/avatar.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/test/unit/spec/avatar.js
@@ -27,6 +27,7 @@ describe(`plugin-avatar`, () => {
     avatar.config.batcherMaxWait = 100;
     avatar.config.defaultMaxAge = 60 * 60;
     avatar.config.defaultAvatarSize = 80;
+    avatar.config.cacheControl = 3600;
   });
 
   describe(`#retrieveAvatarUrl()`, () => {

--- a/packages/node_modules/@ciscospark/plugin-avatar/test/unit/spec/avatar.js
+++ b/packages/node_modules/@ciscospark/plugin-avatar/test/unit/spec/avatar.js
@@ -25,7 +25,7 @@ describe(`plugin-avatar`, () => {
     avatar.config.batcherWait = 1500;
     avatar.config.batcherMaxCalls = 100;
     avatar.config.batcherMaxWait = 100;
-    avatar.config.cacheExpiration = 60 * 60;
+    avatar.config.defaultMaxAge = 60 * 60;
     avatar.config.defaultAvatarSize = 80;
   });
 
@@ -43,15 +43,13 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                cacheControl: `public max-age=3600`
               }
             }
           },
           statusCode: 200,
           options: {
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
@@ -74,13 +72,11 @@ describe(`plugin-avatar`, () => {
             headers: {
               trackingid: `tid`
             },
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [80]
+                sizes: [80],
+                cacheControl: `public max-age=3600`
               }
             ]
           }
@@ -95,15 +91,13 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               110: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                cacheControl: `public max-age=3600`
               }
             }
           },
           statusCode: 200,
           options: {
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
@@ -122,15 +116,13 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               35: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                cacheControl: `public max-age=3600`
               }
             }
           },
           statusCode: 200,
           options: {
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
@@ -151,22 +143,20 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`,
+                cacheControl: `public max-age=3600`
               }
             }
           },
           statusCode: 200,
           options: {
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-              `88888888-4444-4444-4444-aaaaaaaaaaa1`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
@@ -199,18 +189,16 @@ describe(`plugin-avatar`, () => {
             headers: {
               trackingid: `tid`
             },
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-              `88888888-4444-4444-4444-aaaaaaaaaaa1`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [80]
+                sizes: [80],
+                cacheControl: `public max-age=3600`
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`,
-                sizes: [80]
+                sizes: [80],
+                cacheControl: `public max-age=3600`
               }
             ]
           }
@@ -234,16 +222,13 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                cacheControl: `public max-age=3600`
               }
             }
           },
           statusCode: 200,
           options: {
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-              `88888888-4444-4444-4444-aaaaaaaaaaa1`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
@@ -272,22 +257,20 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--40`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--40`,
+                cacheControl: `public max-age=3600`
               }
             }
           },
           statusCode: 200,
           options: {
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-              `88888888-4444-4444-4444-aaaaaaaaaaa1`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
@@ -316,22 +299,20 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
               110: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`,
+                cacheControl: `public max-age=3600`
               }
             }
           },
           statusCode: 200,
           options: {
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-              `88888888-4444-4444-4444-aaaaaaaaaaa1`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
@@ -360,26 +341,25 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--40`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--40`,
+                cacheControl: `public max-age=3600`
               },
               110: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`,
+                cacheControl: `public max-age=3600`
               }
             }
           },
           statusCode: 200,
           options: {
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-              `88888888-4444-4444-4444-aaaaaaaaaaa1`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
@@ -409,22 +389,20 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               100: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--110`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--110`,
+                cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
               100: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`,
+                cacheControl: `public max-age=3600`
               }
             }
           },
           statusCode: 200,
           options: {
-            ids: [
-              `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-              `88888888-4444-4444-4444-aaaaaaaaaaa1`
-            ],
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
@@ -441,6 +419,112 @@ describe(`plugin-avatar`, () => {
         return Promise.all([
           assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 100}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--110`),
           assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 100}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`)
+        ])
+          .then(() => {
+            assert.callCount(spark.request, 1);
+          });
+      });
+
+      it(`retrieves a group of avatar urls (with duplicate requests)`, () => {
+
+        spark.request = sinon.stub().returns(Promise.resolve({
+          body: {
+            '88888888-4444-4444-4444-aaaaaaaaaaa0': {
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                cacheControl: `public max-age=3600`
+              }
+            },
+            '88888888-4444-4444-4444-aaaaaaaaaaa1': {
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`,
+                cacheControl: `public max-age=3600`
+              }
+            },
+            '88888888-4444-4444-4444-aaaaaaaaaaa2': {
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`,
+                cacheControl: `public max-age=3600`
+              }
+            },
+            '88888888-4444-4444-4444-aaaaaaaaaaa3': {
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3`,
+                cacheControl: `public max-age=3600`
+              }
+            },
+            '88888888-4444-4444-4444-aaaaaaaaaaa4': {
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`,
+                cacheControl: `public max-age=3600`
+              }
+            },
+            '88888888-4444-4444-4444-aaaaaaaaaaa5': {
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5`,
+                cacheControl: `public max-age=3600`
+              }
+            }
+          },
+          statusCode: 200,
+          options: {
+            body: [
+              {
+                uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                sizes: [80]
+              },
+              {
+                uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`,
+                sizes: [80]
+              },
+              {
+                uuid: `88888888-4444-4444-4444-aaaaaaaaaaa2`,
+                sizes: [80]
+              },
+              {
+                uuid: `88888888-4444-4444-4444-aaaaaaaaaaa3`,
+                sizes: [80]
+              },
+              {
+                uuid: `88888888-4444-4444-4444-aaaaaaaaaaa4`,
+                sizes: [80]
+              },
+              {
+                uuid: `88888888-4444-4444-4444-aaaaaaaaaaa5`,
+                sizes: [80]
+              }
+            ]
+          }
+        }));
+        return Promise.all([
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa3`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
+
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa3`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa5`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5`)
         ])
           .then(() => {
             assert.callCount(spark.request, 1);

--- a/packages/node_modules/@ciscospark/spark-core/src/lib/batcher.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/lib/batcher.js
@@ -61,7 +61,10 @@ const Batcher = SparkPlugin.extend({
         this.prepareItem(item)
           .then((req) => {
             defer.promise = defer.promise
-              .then(() => this.deferreds.delete(idx))
+              .then((res) => {
+                this.deferreds.delete(idx);
+                return res;
+              })
               .catch((reason) => {
                 this.deferreds.delete(idx);
                 return Promise.reject(reason);

--- a/packages/node_modules/@ciscospark/spark-core/src/lib/batcher.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/lib/batcher.js
@@ -7,7 +7,8 @@
 import SparkPlugin from './spark-plugin';
 import {
   cappedDebounce,
-  Defer
+  Defer,
+  tap
 } from '@ciscospark/common';
 import SparkHttpError from './spark-http-error';
 
@@ -61,10 +62,7 @@ const Batcher = SparkPlugin.extend({
         this.prepareItem(item)
           .then((req) => {
             defer.promise = defer.promise
-              .then((res) => {
-                this.deferreds.delete(idx);
-                return res;
-              })
+              .then(tap(() => this.deferreds.delete(idx)))
               .catch((reason) => {
                 this.deferreds.delete(idx);
                 return Promise.reject(reason);


### PR DESCRIPTION
fix(@ciscospark/plugin-avatar): Avatars are not retrieved and stored correctly when attempting to batch large numbers of requests

Fixes #564 

Web client requests many avatars on load and when entering spaces with large numbers of people. These requests are often duplicated many times as well. Usually a duplicate request through spark-core.batcher.request returns a deferred promise that resolves with the original, non-duplicate request's promise. However, these conditions introduce a race condition that can cause a duplicate to be resolved on an original's promise *after* cleanup code defined in batcher.request has been executed. The cleanup causes the promise to resolve to "true" instead of the request response and introduces issue #564. This problem is addressed in commit 074aa8b85f9baaa0d524a5b23cb4b02fb03236ef.

Two other problems were found in plugin-avatar: the cacheControl property of the avatar services response is ignored and avatar-url-store methods were not being called with the correct signature. These bugs caused the avatar cache to keep urls up to 360000 seconds. Additionally, the cache was not flushed of all urls mapped to uuids after successfully uploading a new avatar.

