### PR TITLE
Reimplement filterEscape and restore pre 0.7 convo behavior

### DIFF
--- a/packages/node_modules/@ciscospark/helper-html/src/html.js
+++ b/packages/node_modules/@ciscospark/helper-html/src/html.js
@@ -35,3 +35,5 @@ function noopSync(processCallback, allowedTags, allowedStyles, html) {
 
 export const filter = curry(noop, 4);
 export const filterSync = curry(noopSync, 4);
+export const filterEscape = curry(noop, 4);
+export const filterEscapeSync = curry(noopSync, 4);

--- a/packages/node_modules/@ciscospark/helper-html/src/html.shim.js
+++ b/packages/node_modules/@ciscospark/helper-html/src/html.shim.js
@@ -140,6 +140,117 @@ function _filterSync(processCallback, allowedTags, allowedStyles, html) {
   }
 }
 
+/**
+ * Same as _filter, but escapes rather than removes disallowed values
+ * @param {Function} processCallback
+ * @param {Object} allowedTags
+ * @param {Array<string>} allowedStyles
+ * @param {string} html
+ * @returns {Promise<string>}
+ */
+function _filterEscape(...args) {
+  return new Promise((resolve) => {
+    resolve(_filterEscapeSync(...args));
+  });
+}
+
+/**
+ * Same as _filterSync, but escapes rather than removes disallowed values
+ * @param {Function} processCallback
+ * @param {Object} allowedTags
+ * @param {Array<string>} allowedStyles
+ * @param {string} html
+ * @returns {string}
+ */
+function _filterEscapeSync(processCallback, allowedTags, allowedStyles, html) {
+  if (!html || !allowedStyles || !allowedTags) {
+    if (html.length === 0) {
+      return html;
+    }
+
+    throw new Error(`\`allowedTags\`, \`allowedStyles\`, and \`html\` must be provided`);
+  }
+
+  const doc = (new DOMParser()).parseFromString(html, `text/html`);
+  depthFirstForEach(doc.body.childNodes, filterNode);
+  processCallback(doc.body);
+
+  if (html.indexOf(`body`) === 1) {
+    return `<body>${doc.body.innerHTML}</body>`;
+  }
+
+  return doc.body.innerHTML;
+
+  /**
+   * @param {Node} node
+   * @private
+   * @returns {undefined}
+   */
+  function filterNode(node) {
+    if (!isElement(node)) {
+      return;
+    }
+
+    depthFirstForEach(node.childNodes, filterNode);
+
+    const nodeName = node.nodeName.toLowerCase();
+    const allowedTagNames = Object.keys(allowedTags);
+
+    if (includes(allowedTagNames, nodeName)) {
+      const allowedAttributes = allowedTags[nodeName];
+      forEach(listAttributeNames(node.attributes), (attrName) => {
+        if (!includes(allowedAttributes, attrName)) {
+          node.removeAttribute(attrName);
+        }
+        else if (attrName === `href` || attrName === `src`) {
+          const attrValue = node.attributes.getNamedItem(attrName).value;
+          if (attrValue.indexOf(`javascript:`) === 0) {
+            reparent(node);
+          }
+        }
+        else if (attrName === `style`) {
+          const styles = node
+            .attributes
+            .getNamedItem(`style`)
+            .value
+            .split(`;`)
+            .map((style) => {
+              const styleName = trim(style.split(`:`)[0]);
+              if (includes(allowedStyles, styleName)) {
+                return style;
+              }
+              return null;
+            })
+            .filter((style) => Boolean(style))
+            .join(`;`);
+          node.setAttribute(`style`, styles);
+        }
+      });
+    }
+    else {
+      escapeNode(node);
+    }
+  }
+}
+
+/**
+ * Escapes a given html node
+ * @param {Node} node
+ * @returns {undefined}
+ */
+function escapeNode(node) {
+  const before = document.createTextNode(`<${node.nodeName.toLowerCase()}>`);
+  const after = document.createTextNode(`</${node.nodeName.toLowerCase()}>`);
+
+  node.parentNode.insertBefore(before, node);
+  while (node.childNodes.length > 0) {
+    node.parentNode.insertBefore(node.childNodes[0], node);
+  }
+  node.parentNode.insertBefore(after, node);
+
+  node.remove();
+}
+
 const trimPattern = /^\s|\s$/g;
 /**
  * @param {string} str
@@ -218,3 +329,21 @@ function isElement(o) {
  * @returns {string}
  */
 export const filterSync = curry(_filterSync, 4);
+
+/**
+ * Curried HTML filter that escapes rather than removes disallowed tags
+ * @param {Object} allowedTags Map of tagName -> array of allowed attributes
+ * @param {Array<string>} allowedStyles Array of allowed styles
+ * @param {string} html html to filter
+ * @returns {Promise<string>}
+ */
+export const filterEscape = curry(_filterEscape, 4);
+
+/**
+ * Curried HTML filter that escapes rather than removes disallowed tags
+ * @param {Object} allowedTags Map of tagName -> array of allowed attributes
+ * @param {Array<string>} allowedStyles Array of allowed styles
+ * @param {string} html html to filter
+ * @returns {string}
+ */
+export const filterEscapeSync = curry(_filterEscapeSync, 4);

--- a/packages/node_modules/@ciscospark/helper-html/src/index.js
+++ b/packages/node_modules/@ciscospark/helper-html/src/index.js
@@ -3,4 +3,11 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-export {escape, escapeSync, filter, filterSync} from './html';
+export {
+  escape,
+  escapeSync,
+  filter,
+  filterSync,
+  filterEscape,
+  filterEscapeSync
+} from './html';

--- a/packages/node_modules/@ciscospark/helper-html/test/unit/spec/html.js
+++ b/packages/node_modules/@ciscospark/helper-html/test/unit/spec/html.js
@@ -4,7 +4,14 @@
  */
 
 import {assert} from '@ciscospark/test-helper-chai';
-import {escape, escapeSync, filter, filterSync} from '@ciscospark/helper-html';
+import {
+  escape,
+  escapeSync,
+  filter,
+  filterSync,
+  filterEscape,
+  filterEscapeSync
+} from '@ciscospark/helper-html';
 import {skipInNode} from '@ciscospark/test-helper-mocha';
 
 skipInNode(describe)(`html`, () => {
@@ -13,6 +20,7 @@ skipInNode(describe)(`html`, () => {
     em: [],
     strong: [],
     a: [`style`, `href`, `type`],
+    b: [],
     blockquote: [`style`],
     cite: [`style`],
     img: [`style`, `alt`, `height`, `src`, `width`],
@@ -47,6 +55,8 @@ skipInNode(describe)(`html`, () => {
   }
   const cfilter = filter(noop, allowedTags, allowedStyles);
   const cfilterSync = filterSync(noop, allowedTags, allowedStyles);
+  const cfilterEscape = filterEscape(noop, allowedTags, allowedStyles);
+  const cfilterEscapeSync = filterEscapeSync(noop, allowedTags, allowedStyles);
 
   describe(`#filter()`, () => {
     it(`sanitizes trivial html`, () => {
@@ -195,6 +205,39 @@ skipInNode(describe)(`html`, () => {
     describe(`#escapeSync()`, () => {
       it(def.it, () => {
         assert.deepEqual(escapeSync(def.input), def.output);
+      });
+    });
+  });
+
+  [
+    {
+      it: `escapes invalid tags`,
+      input: `<bar>text1<em>text2</em>text3</bar>`,
+      output: `&lt;bar&gt;text1<em>text2</em>text3&lt;/bar&gt;`
+    },
+    {
+      it: `escapes deeply nested invalid tags`,
+      input: `<p><remove-me><bar>text1<em>text2</em>text3</bar>text4</remove-me><strong>text5</strong>text6</p>`,
+      output: `<p>&lt;remove-me&gt;&lt;bar&gt;text1<em>text2</em>text3&lt;/bar&gt;text4&lt;/remove-me&gt;<strong>text5</strong>text6</p>`
+    },
+    {
+      it: `esapes special characters`,
+      input: `<b>&<</b>`,
+      output: `<b>&amp;&lt;</b>`
+    }
+  ].forEach((def) => {
+    describe(`#filterEscape()`, () => {
+      it(def.it, () => {
+        return cfilterEscape(def.input)
+          .then((out) => {
+            assert.match(out, def.output);
+          });
+      });
+    });
+
+    describe(`#filterEscapeSync()`, () => {
+      it(def.it, () => {
+        assert.match(cfilterEscapeSync(def.input), def.output);
       });
     });
   });

--- a/packages/node_modules/@ciscospark/plugin-conversation/src/index.js
+++ b/packages/node_modules/@ciscospark/plugin-conversation/src/index.js
@@ -8,7 +8,7 @@ import '@ciscospark/plugin-encryption';
 import '@ciscospark/plugin-user';
 
 import {patterns} from '@ciscospark/common';
-import {filter as htmlFilter} from '@ciscospark/helper-html';
+import {filter as htmlFilter, filterEscape as htmlFilterEscape} from '@ciscospark/helper-html';
 import {registerPlugin} from '@ciscospark/spark-core';
 import Conversation from './conversation';
 import config from './config';
@@ -141,7 +141,7 @@ registerPlugin(`conversation`, Conversation, {
             allowedOutboundStyles
           } = ctx.spark.config.conversation;
 
-          return htmlFilter(outboundProcessFunc, allowedOutboundTags || {}, allowedOutboundStyles, object.content)
+          return htmlFilterEscape(outboundProcessFunc, allowedOutboundTags || {}, allowedOutboundStyles, object.content)
             .then((c) => {
               object.content = c;
             });

--- a/packages/node_modules/@ciscospark/plugin-conversation/test/integration/spec/verbs.js
+++ b/packages/node_modules/@ciscospark/plugin-conversation/test/integration/spec/verbs.js
@@ -261,40 +261,40 @@ describe(`plugin-conversation`, function() {
             allowedOutboundTags: {div: []},
             allowedInboundTags: {div: []},
             outboundMessage: `<div>HELLO</div>`,
-            outboundFileredMessage: `<div>HELLO</div>`,
+            outboundFilteredMessage: `<div>HELLO</div>`,
             inboundMessage: `<div>HELLO</div>`
           },
           {
-            it: `filters disallowed outbound tags`,
+            it: `filters and escapes disallowed outbound tags`,
             allowedOutboundTags: {},
             allowedInboundTags: {},
             outboundMessage: `<div><b>HELLO</b></div>`,
-            outboundFileredMessage: `HELLO`,
-            inboundMessage: `HELLO`
+            outboundFilteredMessage: `&lt;div&gt;&lt;b&gt;HELLO&lt;/b&gt;&lt;/div&gt;`,
+            inboundMessage: `&lt;div&gt;&lt;b&gt;HELLO&lt;/b&gt;&lt;/div&gt;`
           },
           {
             it: `filters disallowed inbound tags`,
             allowedOutboundTags: {div: [], b: []},
             allowedInboundTags: {b: []},
             outboundMessage: `<div><b>HELLO</b></div>`,
-            outboundFileredMessage: `<div><b>HELLO</b></div>`,
+            outboundFilteredMessage: `<div><b>HELLO</b></div>`,
             inboundMessage: `<b>HELLO</b>`
           },
           {
-            it: `filters the correct outbound tags`,
+            it: `filters and escapes the correct outbound tags`,
             allowedOutboundTags: {div: [], span: []},
             allowedInboundTags: {},
             outboundMessage: `<div><b>HELLO</b><span> it's me</span></div>`,
-            outboundFileredMessage: `<div>HELLO<span> it's me</span></div>`,
-            inboundMessage: `HELLO it's me`
+            outboundFilteredMessage: `<div>&lt;b&gt;HELLO&lt;/b&gt;<span> it's me</span></div>`,
+            inboundMessage: `&lt;b&gt;HELLO&lt;/b&gt; it's me`
           },
           {
-            it: `filters the correct inbound and outbound tags`,
+            it: `filters the correct inbound tags and filters and escapes the correct outbound tags`,
             allowedOutboundTags: {div: [], span: []},
             allowedInboundTags: {span: []},
             outboundMessage: `<div><b>HELLO</b><span> it's me</span></div>`,
-            outboundFileredMessage: `<div>HELLO<span> it's me</span></div>`,
-            inboundMessage: `HELLO<span> it's me</span>`
+            outboundFilteredMessage: `<div>&lt;b&gt;HELLO&lt;/b&gt;<span> it's me</span></div>`,
+            inboundMessage: `&lt;b&gt;HELLO&lt;/b&gt;<span> it's me</span>`
           }
         ].forEach((def) => {
           it(def.it, () => {
@@ -308,7 +308,7 @@ describe(`plugin-conversation`, function() {
               content: def.outboundMessage
             })
             .then((activity) => {
-              assert.equal(activity.object.content, def.outboundFileredMessage);
+              assert.equal(activity.object.content, def.outboundFilteredMessage);
               mccoy.spark.config.conversation.allowedInboundTags = def.allowedInboundTags;
               return mccoy.spark.conversation.get(conversation, {activitiesLimit: 1});
             })


### PR DESCRIPTION
I'm not really convinced this is the right behavior for convo, but it's what the web client does now. After updating the convo tests and a conversation with @pcl, I'm reasonably convinced the right behavior is to reject messaged with disallowed html. That, however, is a PM/UX decision that'll need to be made product wide. Until then, this seems to be the "most correct" of the available options.