### PR TITLE
Fixes namespace of requestAuthorizationCodeGrant in node documentation

### DIFF
--- a/docs/_posts/guides/9999-01-04-servers.md
+++ b/docs/_posts/guides/9999-01-04-servers.md
@@ -75,7 +75,7 @@ app.get(`/login`, (req, res) => {
 
 app.get(`/oauth/redirect`, (req, res) => {
   assert(req.params.code);
-  req.spark.requestAuthorizationCodeGrant(req.params)
+  req.spark.authorization.requestAuthorizationCodeGrant(req.params)
     .then(() => {
       res.redirect(`/`).end();
     });


### PR DESCRIPTION
requestAuthorizationCodeGrant namespace was incorrect in last example even though it was corrected in a previous example.