### PR TITLE
refactor(@ciscospark/i-plugin-support): call getUserToken on submitLogs

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-support/src/support.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-support/src/support.js
@@ -54,7 +54,7 @@ const Support = SparkPlugin.extend({
     }
 
     let userId;
-    return this.spark.credentials.getAuthorization()
+    return this.spark.credentials.getUserToken()
       .catch(() => this.spark.credentials.getClientToken())
       .then((token) => {
         const headers = {authorization: token.toString()};

--- a/packages/node_modules/@ciscospark/internal-plugin-support/test/integration/spec/support.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-support/test/integration/spec/support.js
@@ -29,7 +29,7 @@ describe(`plugin-support`, function() {
     }));
 
   // Disabled because rackspace is broken
-  describe.skip(`#submitLogs()`, () => {
+  describe(`#submitLogs()`, () => {
     describe(`when the current user is authorized`, () => {
       before(() => testUsers.create({count: 1})
         .then((users) => {

--- a/packages/node_modules/@ciscospark/internal-plugin-support/test/unit/spec/support.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-support/test/unit/spec/support.js
@@ -34,4 +34,11 @@ describe(`plugin-support`, function() {
     });
   });
 
+  describe(`#submitLogs()`, () => {
+    it(`calls getUserToken`, () => {
+      spark.internal.support.submitLogs({});
+      assert.calledOnce(spark.credentials.getUserToken);
+    });
+  });
+
 });


### PR DESCRIPTION
Fixes failure to upload logs from web-client