### PR TITLE
fix(internal-plugin-conversation): handle user and convo creation errors

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -10,6 +10,7 @@ import {cloneDeep, defaults, isArray, isObject, isString, last, map, merge, omit
 import {readExifData} from '@ciscospark/helper-image';
 import uuid from 'uuid';
 import querystring from 'querystring';
+import {InvalidUserCreation} from './convo-error';
 import ShareActivity from './share-activity';
 import {EventEmitter} from 'events';
 
@@ -73,24 +74,45 @@ const Conversation = SparkPlugin.extend({
    * @param {string} params.comment
    * @param {Object} params.displayName
    * @param {Object} options
+   * @param {Boolean} options.allowPartialCreation
    * @param {Boolean} options.forceGrouped
+   * @param {Boolean} options.skipOneOnOneFetch skips checking 1:1 exists before creating conversation
    * @returns {Promise<Conversation>}
    */
   create(params, options) {
+    options = options || {};
+
     if (!params.participants || params.participants.length === 0) {
       return Promise.reject(new Error(`\`params.participants\` is required`));
     }
 
-    return Promise.all(params.participants.map((participant) => this.spark.internal.user.asUUID(participant, {create: true})))
+    return Promise.all(params.participants.map((participant) => this.spark.internal.user.asUUID(participant, {create: true})
+      // eslint-disable-next-line arrow-body-style
+      .catch((err) => {
+        return options.allowPartialCreation ? undefined : Promise.reject(err);
+      })
+    ))
       .then((participants) => {
-        participants.unshift(this.spark.internal.device.userId);
-        params.participants = uniq(participants);
 
-        if (params.participants.length === 2 && !(options && options.forceGrouped)) {
+        participants.unshift(this.spark.internal.device.userId);
+        participants = uniq(participants);
+
+        const validParticipants = participants.filter((participant) => participant);
+        params.participants = validParticipants;
+
+        // check if original participants list was to create a 1:1
+        if (participants.length === 2 && !(options && options.forceGrouped)) {
+          if (!params.participants[1]) {
+            return Promise.reject(new InvalidUserCreation());
+          }
+
+          if (options.skipOneOnOneFetch) {
+            return this._createOneOnOne(params);
+          }
           return this._maybeCreateOneOnOneThenPost(params, options);
         }
 
-        return this._createGrouped(params);
+        return this._createGrouped(params, options);
       })
       .then((c) => {
         if (!params.files) {
@@ -225,6 +247,7 @@ const Conversation = SparkPlugin.extend({
             uuidEntryFormat: true,
             personRefresh: true,
             activitiesLimit: 0,
+            includeConvWithDeletedUserUUID: false,
             includeParticipants: false
           }, omit(options, `id`, `user`, `url`))
         };
@@ -734,26 +757,44 @@ const Conversation = SparkPlugin.extend({
 
   /**
    * @param {Object} payload
+   * @param {Object} options
    * @private
    * @returns {Promise<Activity>}
    */
-  _create(payload) {
+  _create(payload, options) {
+    options = options || {};
     return this.request({
       method: `POST`,
       service: `conversation`,
       resource: `conversations`,
-      body: payload
+      body: payload,
+      qs: {
+        forceCreate: options.allowPartialCreation
+      }
     })
       .then((res) => res.body);
   },
 
   /**
    * @param {Object} params
+   * @param {Object} options
    * @private
    * @returns {Promise}
    */
-  _createGrouped(params) {
-    return this._create(this._prepareConversationForCreation(params));
+  _createGrouped(params, options) {
+    return this._create(this._prepareConversationForCreation(params), options);
+  },
+
+  /**
+   * @param {Object} params
+   * @param {Object} options
+   * @private
+   * @returns {Promise}
+   */
+  _createOneOnOne(params) {
+    const payload = this._prepareConversationForCreation(params);
+    payload.tags = [`ONE_ON_ONE`];
+    return this._create(payload);
   },
 
   /**
@@ -827,16 +868,17 @@ const Conversation = SparkPlugin.extend({
    * @returns {Promise<Conversation>}
    */
   _maybeCreateOneOnOneThenPost(params, options) {
+
     return this.get(defaults({
       // the use of uniq in Conversation#create guarantees participant[1] will
       // always be the other user
       user: params.participants[1]
-    }), options)
+    }), Object.assign(options, {includeConvWithDeletedUserUUID: true, includeParticipants: true}))
       .then((conversation) => {
         if (params.comment) {
           return this.post(conversation, {displayName: params.comment})
             .then((activity) => {
-              conversation.activities.push(activity);
+              conversation.activities.items.push(activity);
               return conversation;
             });
         }
@@ -848,9 +890,7 @@ const Conversation = SparkPlugin.extend({
           return Promise.reject(reason);
         }
 
-        const payload = this._prepareConversationForCreation(params);
-        payload.tags = [`ONE_ON_ONE`];
-        return this._create(payload);
+        return this._createOneOnOne(params);
       });
   },
 

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/convo-error.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/convo-error.js
@@ -1,0 +1,11 @@
+import {Exception} from '@ciscospark/common';
+
+/**
+ * General conversation error
+ */
+export class ConversationError extends Exception {}
+
+/**
+ * InvalidUserCreation thrown when failed to create conversation with invalid user
+ */
+export class InvalidUserCreation extends ConversationError {}

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/index.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/index.js
@@ -215,3 +215,4 @@ registerInternalPlugin(`conversation`, Conversation, {
 
 export {default as default} from './conversation';
 export {default as ShareActivity} from './share-activity';
+export {ConversationError, InvalidUserCreation} from './convo-error';

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/create.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/create.js
@@ -6,21 +6,23 @@
 import '@ciscospark/internal-plugin-conversation';
 
 import {patterns} from '@ciscospark/common';
-import CiscoSpark from '@ciscospark/spark-core';
+import CiscoSpark, {SparkHttpError} from '@ciscospark/spark-core';
 import {assert} from '@ciscospark/test-helper-chai';
 import testUsers from '@ciscospark/test-helper-test-users';
 import {find, last, map} from 'lodash';
 import uuid from 'uuid';
 import fh from '@ciscospark/test-helper-file';
+import {InvalidUserCreation} from '@ciscospark/internal-plugin-conversation';
 
 describe(`plugin-conversation`, function() {
   this.timeout(60000);
   describe(`#create()`, () => {
-    let checkov, mccoy, participants, spark, spock;
+    let checkov, kirk, mccoy, participants, spark, spock;
 
-    before(() => testUsers.create({count: 3})
+    before(() => testUsers.create({count: 4})
       .then((users) => {
-        participants = [spock, mccoy, checkov] = users;
+        [spock, mccoy, checkov, kirk] = users;
+        participants = [spock, mccoy, checkov];
 
         spark = new CiscoSpark({
           credentials: {
@@ -81,9 +83,27 @@ describe(`plugin-conversation`, function() {
       });
 
       describe(`when the conversation already exists`, () => {
+        describe(`with skipOneOnOneFetch=true`, () => {
+          it(`fails to create a 1:1 conversation that already exists`, () => assert.isRejected(spark.internal.conversation.create({participants: [mccoy]}, {skipOneOnOneFetch: true}))
+            .then((reason) => assert.instanceOf(reason, SparkHttpError.Conflict)));
+        });
+
         it(`returns the preexisting conversation`, () => spark.internal.conversation.create({participants: [checkov]})
           .then((conversation) => spark.internal.conversation.create({participants: [checkov]})
-            .then((conversation2) => assert.equal(conversation2.url, conversation.url))));
+            .then((conversation2) => {
+              assert.equal(conversation2.url, conversation.url);
+              assert.lengthOf(conversation.activities.items, 1);
+              assert.equal(conversation.activities.items[0].verb, `create`);
+            })));
+
+        it(`returns the preexisting conversation and posts a comment`, () => spark.internal.conversation.create({participants: [checkov], comment: `hi`})
+          .then((conversation) => spark.internal.conversation.create({participants: [checkov]})
+            .then((conversation2) => {
+              assert.equal(conversation2.url, conversation.url);
+              assert.lengthOf(conversation.activities.items, 1);
+              assert.equal(conversation.activities.items[0].verb, `post`);
+              assert.equal(conversation.activities.items[0].object.displayName, `hi`);
+            })));
       });
 
       describe(`when {forceGrouped: true} is specified`, () => {
@@ -97,6 +117,40 @@ describe(`plugin-conversation`, function() {
             assert.lengthOf(conversation.activities.items, 1);
           }));
       });
+    });
+
+    describe(`when there is an invalid user in the participants list`, () => {
+
+      describe(`with allowPartialCreation`, () => {
+        it(`creates a group conversation`, () => spark.internal.conversation.create({participants: [mccoy, `invalidUser`]}, {allowPartialCreation: true})
+          .then((conversation) => {
+            assert.isConversation(conversation);
+            assert.isGroupConversation(conversation);
+            assert.isNewEncryptedConversation(conversation);
+
+            assert.lengthOf(conversation.participants.items, 2);
+            assert.lengthOf(conversation.activities.items, 1);
+          }));
+
+        it(`creates a group conversation with invalid uuid`, () => testUsers.remove([kirk])
+          .then(() => spark.internal.conversation.create({participants: [mccoy.id, kirk.id]}, {allowPartialCreation: true}))
+          .then((conversation) => {
+            assert.isConversation(conversation);
+            assert.isGroupConversation(conversation);
+            assert.isNewEncryptedConversation(conversation);
+
+            assert.lengthOf(conversation.participants.items, 2);
+            assert.lengthOf(conversation.activities.items, 1);
+          }));
+
+        it(`fails to create a 1:1 conversation`, () => assert.isRejected(spark.internal.conversation.create({participants: [`invalidUser`]}, {allowPartialCreation: true}))
+          .then((reason) => assert.instanceOf(reason, InvalidUserCreation)));
+      });
+
+      describe(`without allowPartialCreation`, () => {
+        it(`fails to create a group conversation without allowPartialCreation param`, () => assert.isRejected(spark.internal.conversation.create({participants: [mccoy, `invalidUser`]})));
+      });
+
     });
 
     describe(`when {compact: ?} is not specified`, () => {

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/get.js
@@ -16,11 +16,14 @@ import {map} from 'lodash';
 describe(`plugin-conversation`, function() {
   this.timeout(120000);
 
-  let mccoy, participants, spark, spock;
+  describe(`when fetching conversations`, () => {
 
-  before(`create tests users and connect one to mercury`, () => testUsers.create({count: 3})
+    let kirk, mccoy, participants, scott, spark, spock;
+
+    before(`create tests users and connect one to mercury`, () => testUsers.create({count: 4})
     .then((users) => {
-      participants = [spock, mccoy] = users;
+      [spock, mccoy, kirk, scott] = users;
+      participants = [spock, mccoy, kirk];
 
       spark = new CiscoSpark({
         credentials: {
@@ -31,101 +34,119 @@ describe(`plugin-conversation`, function() {
       return spark.internal.mercury.connect();
     }));
 
-  after(() => spark && spark.internal.mercury.disconnect());
+    after(() => spark && spark.internal.mercury.disconnect());
 
-  describe(`#download()`, () => {
-    let sampleImageSmallOnePng = `sample-image-small-one.png`;
+    describe(`#download()`, () => {
+      let sampleImageSmallOnePng = `sample-image-small-one.png`;
 
-    let conversation;
-    before(`create conversation`, () => spark.internal.conversation.create({participants})
+      let conversation;
+      before(`create conversation`, () => spark.internal.conversation.create({participants})
       .then((c) => {conversation = c;}));
 
-    before(`fetch image fixture`, () => fh.fetch(sampleImageSmallOnePng)
+      before(`fetch image fixture`, () => fh.fetch(sampleImageSmallOnePng)
       .then((res) => {sampleImageSmallOnePng = res;}));
 
-    it(`downloads and decrypts an encrypted file`, () => spark.internal.conversation.share(conversation, [sampleImageSmallOnePng])
+      it(`downloads and decrypts an encrypted file`, () => spark.internal.conversation.share(conversation, [sampleImageSmallOnePng])
       .then((activity) => spark.internal.conversation.download(activity.object.files.items[0]))
       .then((f) => assert.eventually.isTrue(fh.isMatchingFile(f, sampleImageSmallOnePng))));
 
-    it(`emits download progress events for encrypted files`, () => spark.internal.conversation.share(conversation, [sampleImageSmallOnePng])
+      it(`emits download progress events for encrypted files`, () => spark.internal.conversation.share(conversation, [sampleImageSmallOnePng])
       .then((activity) => {
         const spy = sinon.spy();
         return spark.internal.conversation.download(activity.object.files.items[0])
-          .on(`progress`, spy)
-          .then(() => assert.called(spy));
+        .on(`progress`, spy)
+        .then(() => assert.called(spy));
       }));
 
-    it(`downloads and decrypts a non-encrypted file`, () => spark.internal.conversation.download({url: makeLocalUrl(`/sample-image-small-one.png`)})
+      it(`downloads and decrypts a non-encrypted file`, () => spark.internal.conversation.download({url: makeLocalUrl(`/sample-image-small-one.png`)})
       .then((f) => assert.eventually.isTrue(fh.isMatchingFile(f, sampleImageSmallOnePng))));
 
-    it(`emits download progress events for non-encrypted files`, () => {
-      const spy = sinon.spy();
-      return spark.internal.conversation.download({url: makeLocalUrl(`/sample-image-small-one.png`)})
+      it(`emits download progress events for non-encrypted files`, () => {
+        const spy = sinon.spy();
+        return spark.internal.conversation.download({url: makeLocalUrl(`/sample-image-small-one.png`)})
         .on(`progress`, spy)
         .then((f) => assert.eventually.isTrue(fh.isMatchingFile(f, sampleImageSmallOnePng)))
         .then(() => assert.called(spy));
+      });
     });
-  });
 
-  describe(`#get()`, () => {
-    let conversation;
-    before(`create conversation`, () => spark.internal.conversation.create({participants: [mccoy.id]})
-      .then((c) => {conversation = c;}));
+    describe(`#get()`, () => {
+      let conversation, conversation2;
 
-    it(`retrieves a single conversation by url`, () => spark.internal.conversation.get({url: conversation.url})
+      before(`create conversations`, () => Promise.all([
+        spark.internal.conversation.create({participants: [mccoy.id]})
+        .then((c) => {conversation = c;}),
+        spark.internal.conversation.create({participants: [scott.id]})
+        .then((c) => {conversation2 = c;})
+      ]));
+
+      it(`retrieves a single conversation by url`, () => spark.internal.conversation.get({url: conversation.url})
       .then((c) => {
         assert.equal(c.id, conversation.id);
         assert.equal(c.url, conversation.url);
       }));
 
-    it(`retrieves a single conversation by id`, () => spark.internal.conversation.get({id: conversation.id})
+      it(`retrieves a single conversation by id`, () => spark.internal.conversation.get({id: conversation.id})
       .then((c) => {
         assert.equal(c.id, conversation.id);
         assert.equal(c.url, conversation.url);
       }));
 
-    it(`retrieves a 1:1 conversation by userId`, () => spark.internal.conversation.get({user: mccoy})
+      it(`retrieves a 1:1 conversation by userId`, () => spark.internal.conversation.get({user: mccoy})
       .then((c) => {
         assert.equal(c.id, conversation.id);
         assert.equal(c.url, conversation.url);
       }));
 
-    it(`decrypts the contents of activities in the retrieved conversation`, () => spark.internal.conversation.post(conversation, {
-      displayName: `Test Message`
-    })
+      it(`retrieves a 1:1 conversation with a deleted user`, () => spark.internal.conversation.get({user: scott})
+      .then((c) => {
+        assert.equal(c.id, conversation2.id);
+        assert.equal(c.url, conversation2.url);
+      })
+      .then(() => testUsers.remove([scott]))
+      .then(() => assert.isRejected(spark.internal.conversation.get({user: scott})))
+      .then(() => spark.internal.conversation.get({user: scott}, {includeConvWithDeletedUserUUID: true}))
+      .then((c) => {
+        assert.equal(c.id, conversation2.id);
+        assert.equal(c.url, conversation2.url);
+      }));
+
+      it(`decrypts the contents of activities in the retrieved conversation`, () => spark.internal.conversation.post(conversation, {
+        displayName: `Test Message`
+      })
       .then(() => spark.internal.conversation.get({url: conversation.url}, {activitiesLimit: 50}))
       .then((c) => {
         const posts = c.activities.items.filter((activity) => activity.verb === `post`);
         assert.lengthOf(posts, 1);
         assert.equal(posts[0].object.displayName, `Test Message`);
       }));
-  });
+    });
 
-  describe(`#list()`, () => {
-    let conversation1, conversation2;
+    describe(`#list()`, () => {
+      let conversation1, conversation2;
 
-    before(`create conversations`, () => Promise.all([
-      spark.internal.conversation.create({participants})
+      before(`create conversations`, () => Promise.all([
+        spark.internal.conversation.create({participants})
         .then((c) => {conversation1 = c;}),
-      spark.internal.conversation.create({participants})
+        spark.internal.conversation.create({participants})
         .then((c) => {conversation2 = c;})
-    ]));
+      ]));
 
-    it(`retrieves a set of conversations`, () => spark.internal.conversation.list({
-      conversationsLimit: 2
-    })
+      it(`retrieves a set of conversations`, () => spark.internal.conversation.list({
+        conversationsLimit: 2
+      })
       .then((conversations) => {
         assert.include(map(conversations, `url`), conversation1.url);
         assert.include(map(conversations, `url`), conversation2.url);
       }));
-  });
+    });
 
-  describe(`#listLeft()`, () => {
-    let conversation;
-    before(`create conversation`, () => spark.internal.conversation.create({participants})
+    describe(`#listLeft()`, () => {
+      let conversation;
+      before(`create conversation`, () => spark.internal.conversation.create({participants})
       .then((c) => {conversation = c;}));
 
-    it(`retrieves the conversations the current user has left`, () => spark.internal.conversation.listLeft()
+      it(`retrieves the conversations the current user has left`, () => spark.internal.conversation.listLeft()
       .then((c) => {
         assert.lengthOf(c, 0);
         return spark.internal.conversation.leave(conversation);
@@ -135,62 +156,64 @@ describe(`plugin-conversation`, function() {
         assert.lengthOf(c, 1);
         assert.equal(c[0].url, conversation.url);
       }));
-  });
+    });
 
-  describe(`#listActivities()`, () => {
-    let conversation;
-    before(`create conversation with activity`, () => spark.internal.conversation.create({participants})
+    describe(`#listActivities()`, () => {
+      let conversation;
+      before(`create conversation with activity`, () => spark.internal.conversation.create({participants})
       .then((c) => {
         conversation = c;
         assert.lengthOf(conversation.participants.items, 3);
         return spark.internal.conversation.post(conversation, {displayName: `first message`});
       }));
 
-    it(`retrieves activities for the specified conversation`, () => spark.internal.conversation.listActivities({conversationId: conversation.id})
+      it(`retrieves activities for the specified conversation`, () => spark.internal.conversation.listActivities({conversationId: conversation.id})
       .then((activities) => {
         assert.isArray(activities);
         assert.lengthOf(activities, 2);
       }));
-  });
-
-  describe(`#listMentions()`, () => {
-    let spark2;
-
-    before(`connect mccoy to mercury`, () => {
-      spark2 = new CiscoSpark({
-        credentials: {
-          authorization: mccoy.token
-        }
-      });
-
-      return spark2.internal.mercury.connect();
     });
 
-    after(() => spark2 && spark2.internal.mercury.disconnect());
+    describe(`#listMentions()`, () => {
+      let spark2;
 
-    let conversation;
-    before(`create conversation`, () => spark.internal.conversation.create({participants})
+      before(`connect mccoy to mercury`, () => {
+        spark2 = new CiscoSpark({
+          credentials: {
+            authorization: mccoy.token
+          }
+        });
+
+        return spark2.internal.mercury.connect();
+      });
+
+      after(() => spark2 && spark2.internal.mercury.disconnect());
+
+      let conversation;
+      before(`create conversation`, () => spark.internal.conversation.create({participants})
       .then((c) => {
         conversation = c;
         assert.lengthOf(conversation.participants.items, 3);
       }));
 
-    it(`retrieves activities in which the current user was mentioned`, () => spark2.internal.conversation.post(conversation, {
-      displayName: `Green blooded hobgloblin`,
-      content: `<spark-mention data-object-type="person" data-object-id="${spock.id}">Green blooded hobgloblin</spark-mention>`,
-      mentions: {
-        items: [{
-          id: `${spock.id}`,
-          objectType: `person`
-        }]
-      }
-    })
+      it(`retrieves activities in which the current user was mentioned`, () => spark2.internal.conversation.post(conversation, {
+        displayName: `Green blooded hobgloblin`,
+        content: `<spark-mention data-object-type="person" data-object-id="${spock.id}">Green blooded hobgloblin</spark-mention>`,
+        mentions: {
+          items: [{
+            id: `${spock.id}`,
+            objectType: `person`
+          }]
+        }
+      })
       .then((activity) => {
         return spark.internal.conversation.listMentions({sinceDate: Date.parse(activity.published) - 1})
-          .then((mentions) => {
-            assert.lengthOf(mentions, 1);
-            assert.equal(mentions[0].url, activity.url);
-          });
+        .then((mentions) => {
+          assert.lengthOf(mentions, 1);
+          assert.equal(mentions[0].url, activity.url);
+        });
       }));
+    });
   });
+
 });

--- a/packages/node_modules/@ciscospark/internal-plugin-user/src/user-uuid-batcher.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-user/src/user-uuid-batcher.js
@@ -28,7 +28,19 @@ const AbstractUserUUIDRequestBatcher = Batcher.extend({
    * @returns {Promise}
    */
   handleHttpSuccess(res) {
-    return Promise.all(Object.keys(res.body).map((email) => this.handleItemSuccess(email, res.body[email])));
+    return Promise.all(Object.keys(res.body).map((email) => {
+      if (res.body[email] && res.body[email].id) {
+        return this.handleItemSuccess(email, res.body[email]);
+      }
+      return this.handleItemFailure(email, res.body[email]);
+    }));
+  },
+
+  handleItemFailure(email, response) {
+    return this.getDeferredForResponse(email)
+      .then((defer) => {
+        defer.reject(response);
+      });
   },
 
   /**

--- a/packages/node_modules/@ciscospark/internal-plugin-user/test/unit/spec/user-uuid-batcher.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-user/test/unit/spec/user-uuid-batcher.js
@@ -1,0 +1,89 @@
+/**!
+ *
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+import {assert} from '@ciscospark/test-helper-chai';
+import MockSpark from '@ciscospark/test-helper-mock-spark';
+import sinon from '@ciscospark/test-helper-sinon';
+import User from '@ciscospark/internal-plugin-user';
+
+describe(`plugin-user`, () => {
+  describe(`UserUUIDBatcher`, () => {
+    let batcher;
+    let spark;
+
+    beforeEach(() => {
+      spark = new MockSpark({
+        children: {
+          user: User
+        }
+      });
+      batcher = spark.internal.user.batcher.creator;
+    });
+
+    describe(`#fingerprints`, () => {
+      const email = `test@example.com`;
+      it(`fingerprintRequest returns 'email'`, () => assert.becomes(batcher.fingerprintRequest(email), email));
+      it(`fingerprintResponse returns 'email'`, () => assert.becomes(batcher.fingerprintRequest({email}), email));
+    });
+
+    describe(`#submitHttpRequest()`, () => {
+      const email = `test@example.com`;
+      const mockRequest = {
+        method: `POST`,
+        service: `conversation`,
+        resource: `/users`,
+        body: email,
+        qs: {
+          shouldCreateUsers: true
+        }
+      };
+
+      it(`calls spark.request with expected params`, () => {
+        spark.request = function(options) {
+          return Promise.resolve(options);
+        };
+        return batcher.submitHttpRequest(mockRequest.body)
+          .then((req) => assert.deepEqual(req, mockRequest));
+      });
+    });
+
+    describe(`#handleHttpSuccess()`, () => {
+      const email = `test@example.com`;
+      let failureSpy, successSpy;
+
+      beforeEach(() => {
+        successSpy = sinon.stub(batcher, `handleItemSuccess`);
+        failureSpy = sinon.stub(batcher, `handleItemFailure`);
+      });
+
+      it(`handles item success`, () => {
+        const mockResponse = {
+          [email]: {
+            id: `11111`
+          }
+        };
+        return batcher.handleHttpSuccess({
+          body: mockResponse
+        })
+          .then(() => {
+            assert.calledWith(successSpy, email, mockResponse[email]);
+          });
+      });
+
+      it(`handles item failure`, () => {
+        const mockResponse = {
+          [email]: {
+            errorCode: 11111
+          }
+        };
+        return batcher.handleHttpSuccess({
+          body: mockResponse
+        })
+          .then(() => {
+            assert.calledWith(failureSpy, email, mockResponse[email]);
+          });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Previously, when creating a user, it did not handle the scenario when a user cannot be created. Also, it would fail creating a conversation if there were any invalid users. This PR adds an additional option, which allows the conversation to be created without the invalid users.