### PR TITLE
fix(tooling): add package name linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,12 +58,13 @@
     "check-karma-output": "./scripts/analyze-output.sh",
     "build:package": "echo 'deprecated; just use \"npm run --silent build\"'./tooling/build.js",
     "grunt": "grunt",
-    "lint": "npm run --silent lint:js && npm run --silent lint:jenkinsfile",
+    "lint": "npm run --silent lint:js && npm run --silent lint:jenkinsfile && npm run --silent lint:package-names",
     "lint:commitmsg": "conventional-changelog-lint -e",
     "lint:eslint": "eslint --ignore-pattern 'packages/node_modules/generator-ciscospark/generators/*/templates/**' --ignore-path .gitignore $(npm run --silent lint:eslint:ci-reporter)",
     "lint:eslint:ci-reporter": "bash -c '[[ -n \"${JENKINS}\" ]]' && echo \"-f checkstyle -o reports/style/eslint.xml\" || echo ''",
     "lint:jenkinsfile": "grep -qc '.status' Jenkinsfile && echo 'Use result, not status, in Jenkinsfile' || true",
     "lint:js": "npm run --silent lint:eslint -- .",
+    "lint:package-names": "./tooling/lint-package-names.sh",
     "lint:staged": "lint-staged",
     "release": "grunt release",
     "sauce:start": "./scripts/run-with-sauce.sh ./packages/node_modules/@ciscospark/bin-sauce-connect/bin/sauce-connect start",
@@ -337,6 +338,7 @@
   },
   "lint-staged": {
     "*.js": "lint:eslint",
-    "Jenkinsfile": "lint:jenkinsfile"
+    "Jenkinsfile": "lint:jenkinsfile",
+    "*package.json": "lint:package-names"
   }
 }

--- a/tooling/lint-package-names.sh
+++ b/tooling/lint-package-names.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+PACKAGES=$(echo packages/node_modules/{*,@ciscospark/*} | xargs -n 1 | sed 's/packages\/node_modules\///' | xargs -n 1 | grep -v '^@ciscospark$')
+for PACKAGE in $PACKAGES; do
+  NAME_IN_PACKAGE=$(cat "./packages/node_modules/${PACKAGE}/package.json" | jq -r .name);
+  if [ "${NAME_IN_PACKAGE}" != "${PACKAGE}" ]; then
+   echo "package.json for '${PACKAGE}' contains unexpected package name '${NAME_IN_PACKAGE}'"
+   exit 1
+  fi
+done


### PR DESCRIPTION
We inadvertently published two bad releases because of a package name collision. This linter ensures that package names match their directory name