### PR TITLE
refactor(@ciscospark/eslint-config): Fix ESLint Formatting Errors

### DIFF
--- a/packages/node_modules/@ciscospark/eslint-config/es5.js
+++ b/packages/node_modules/@ciscospark/eslint-config/es5.js
@@ -12,7 +12,7 @@ module.exports = {
     sourceType: 'script',
     ecmaFeatures: {
       globalReturn: false
-    },
+    }
   },
   rules: {
     //

--- a/packages/node_modules/@ciscospark/eslint-config/es5.js
+++ b/packages/node_modules/@ciscospark/eslint-config/es5.js
@@ -4,15 +4,15 @@ module.exports = {
   env: {
     node: true
   },
-  ecmaFeatures: {
-    globalReturn: false
-  },
   globals: {
     Promise: false
   },
   parserOptions: {
     ecmaVersion: 5,
-    sourceType: 'script'
+    sourceType: 'script',
+    ecmaFeatures: {
+      globalReturn: false
+    },
   },
   rules: {
     //

--- a/packages/node_modules/@ciscospark/test-helper-server/src/.eslintrc
+++ b/packages/node_modules/@ciscospark/test-helper-server/src/.eslintrc
@@ -2,9 +2,11 @@
   "env": {
     "es6": false
   },
-  "ecmaFeatures": {
-    "blockBindings": false,
-    "modules": false
+  "parserOptions": {
+    "ecmaFeatures": {
+      "blockBindings": false,
+      "modules": false
+    }
   },
   "rules": {
     "arrow-parens": [0, "always"],

--- a/tooling/.eslintrc.yml
+++ b/tooling/.eslintrc.yml
@@ -1,6 +1,6 @@
 parserOptions:
   ecmaVersion: 2015
-  sourceType: "script"
+  sourceType: "module"
 rules:
   strict:
   - 2

--- a/tooling/babel-plugin-inject-package-version.js
+++ b/tooling/babel-plugin-inject-package-version.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const pkgUp = require(`pkg-up`);
 const t = require(`babel-types`);

--- a/tooling/commands/build.js
+++ b/tooling/commands/build.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const wrapHandler = require(`../lib/wrap-handler`);
 const {list} = require(`../util/package`);

--- a/tooling/commands/dependencies.js
+++ b/tooling/commands/dependencies.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = {
   command: `dependencies`,

--- a/tooling/commands/dependencies/list.js
+++ b/tooling/commands/dependencies/list.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const wrapHandler = require(`../../lib/wrap-handler`);
 const {

--- a/tooling/commands/exec.js
+++ b/tooling/commands/exec.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const wrapHandler = require(`../lib/wrap-handler`);
 const {list, spawn} = require(`../util/package`);

--- a/tooling/commands/openh264.js
+++ b/tooling/commands/openh264.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 module.exports = {
   command: `openh264`,

--- a/tooling/commands/openh264/download.js
+++ b/tooling/commands/openh264/download.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const wrapHandler = require(`../../lib/wrap-handler`);
 const {download} = require(`../../lib/openh264`);

--- a/tooling/commands/test.js
+++ b/tooling/commands/test.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 /* eslint-disable complexity */
 

--- a/tooling/commands/updated.js
+++ b/tooling/commands/updated.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const wrapHandler = require(`../lib/wrap-handler`);
 const {updated} = require(`../lib/updated`);

--- a/tooling/commands/version.js
+++ b/tooling/commands/version.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 module.exports = {
   command: `version`,

--- a/tooling/commands/version/last.js
+++ b/tooling/commands/version/last.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const wrapHandler = require(`../../lib/wrap-handler`);
 const {last} = require(`../../lib/version`);

--- a/tooling/commands/version/next.js
+++ b/tooling/commands/version/next.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const wrapHandler = require(`../../lib/wrap-handler`);
 const {next} = require(`../../lib/version`);

--- a/tooling/commands/version/set.js
+++ b/tooling/commands/version/set.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const wrapHandler = require(`../../lib/wrap-handler`);
 const {set} = require(`../../lib/version`);

--- a/tooling/index.js
+++ b/tooling/index.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env babel-node
 
-'use strict';
-
 // eslint-disable-next-line no-unused-expressions
 require(`yargs`)
   .env(``)

--- a/tooling/karma.js
+++ b/tooling/karma.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
 
-'use strict';
-
 const debug = require(`debug`)(`monorepo:test:karma`);
 const {readFile} = require(`fs-promise`);
 const {stopper} = require(`karma`);

--- a/tooling/lib/async.js
+++ b/tooling/lib/async.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const denodeify = require(`denodeify`);
 

--- a/tooling/lib/build.js
+++ b/tooling/lib/build.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`tooling:build`);
 const {

--- a/tooling/lib/dependencies.js
+++ b/tooling/lib/dependencies.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`tooling:dependencies`);
 const builtins = require(`builtins`);

--- a/tooling/lib/git.js
+++ b/tooling/lib/git.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`tooling:git`);
 const Git = require(`nodegit`);

--- a/tooling/lib/npm.js
+++ b/tooling/lib/npm.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`tooling:npm`);
 const {read} = require(`../util/package`);

--- a/tooling/lib/openh264.js
+++ b/tooling/lib/openh264.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`tooling:openh264`);
 const denodeify = require(`denodeify`);

--- a/tooling/lib/package.js
+++ b/tooling/lib/package.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const _list = require(`../util/package`).list;
 

--- a/tooling/lib/test/common.js
+++ b/tooling/lib/test/common.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`tooling:test:common`);
 const {glob} = require(`../../util/package`);

--- a/tooling/lib/test/index.js
+++ b/tooling/lib/test/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 /* eslint-disable require-jsdoc */
 const debug = require(`debug`)(`tooling:test`);

--- a/tooling/lib/test/karma.js
+++ b/tooling/lib/test/karma.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`tooling:test:karma`);
 const {Server, stopper} = require(`karma`);

--- a/tooling/lib/test/mocha.js
+++ b/tooling/lib/test/mocha.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`tooling:test:mocha`);
 const Mocha = require(`mocha`);

--- a/tooling/lib/updated.js
+++ b/tooling/lib/updated.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`tooling:updated`);
 const _ = require(`lodash`);

--- a/tooling/lib/version.js
+++ b/tooling/lib/version.js
@@ -1,4 +1,4 @@
-'use strict';
+
 const debug = require(`debug`)(`tooling:version`);
 const _ = require(`lodash`);
 const {getDistTag} = require(`./npm`);

--- a/tooling/lib/wrap-handler.js
+++ b/tooling/lib/wrap-handler.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 module.exports = function wrapHandler(fn) {
   return async function wrapper(...args) {

--- a/tooling/util/coverage.js
+++ b/tooling/util/coverage.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 /* eslint-disable require-jsdoc */
 

--- a/tooling/util/package.js
+++ b/tooling/util/package.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const denodeify = require(`denodeify`);
 const g = denodeify(require(`glob`));

--- a/tooling/util/server.js
+++ b/tooling/util/server.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`monorepo:test:server`);
 const path = require(`path`);

--- a/tooling/util/spawn.js
+++ b/tooling/util/spawn.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const debug = require(`debug`)(`monorepo:util`);
 const cp = require(`child_process`);


### PR DESCRIPTION
The ecmaFeatures property must be underneath the parserOptions property
as of ESLint 2.0. Made changes in all necessary files to match this pattern.