### PR TITLE
refactor(@ciscospark/internal-plugin-board): allow image files to have no payload

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
@@ -336,7 +336,8 @@ const Board = SparkPlugin.extend({
    * @memberof Board.BoardService
    * @param {Conversation~ConversationObject} conversation
    * @param {Object} options
-   * @param {number} options.limit Max number of activities to return
+   * @param {number} options.channelsLimit number of boards to return per page
+   * @param {number} options.type type of whiteboard: whiteboard or annotated
    * @returns {Promise<Page<Board~Channel>>} Resolves with an array of Channel items
    */
   getChannels(conversation, options) {
@@ -353,7 +354,7 @@ const Board = SparkPlugin.extend({
         aclUrlLink: conversation.aclUrl
       }
     };
-    assign(params.qs, pick(options, `channelsLimit`));
+    assign(params.qs, pick(options, `channelsLimit`, `type`));
 
     return this.request(params)
       .then((res) => new Page(res, this.spark));

--- a/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
@@ -42,13 +42,14 @@ const Board = SparkPlugin.extend({
    * @memberof Board.BoardService
    * @param  {Board~Channel} channel
    * @param  {File} image - image to be uploaded
+   * @param  {Object} metadata - metadata such as displayName
    * @returns {Promise<Board~Content>}
    */
-  addImage(channel, image) {
+  addImage(channel, image, metadata) {
     return this.spark.internal.board._uploadImage(channel, image)
       .then((scr) => this.spark.internal.board.addContent(channel, [{
         type: `FILE`,
-        displayName: image.name,
+        metadata,
         file: {
           mimeType: image.type,
           scr,
@@ -175,19 +176,27 @@ const Board = SparkPlugin.extend({
    * @returns {Promise<Board~Content>}
    */
   decryptSingleFileContent(encryptionKeyUrl, encryptedContent) {
-    let metadata = {};
+    let metadata = ``;
 
     if (encryptedContent.payload) {
-      metadata = JSON.parse(encryptedContent.payload);
+      metadata = encryptedContent.payload;
     }
 
     return this.spark.internal.encryption.decryptScr(encryptionKeyUrl, encryptedContent.file.scr)
       .then((scr) => {
         encryptedContent.file.scr = scr;
-        return this.spark.internal.encryption.decryptText(encryptionKeyUrl, metadata.displayName);
+        return this.spark.internal.encryption.decryptText(encryptionKeyUrl, metadata);
       })
-      .then((displayName) => {
-        encryptedContent.displayName = displayName;
+      .then((decryptedMetadata) => {
+        try {
+          encryptedContent.metadata = JSON.parse(decryptedMetadata);
+          if (encryptedContent.metadata.displayName) {
+            encryptedContent.displayName = encryptedContent.metadata.displayName;
+          }
+        }
+        catch (error) {
+          encryptedContent.metadata = {};
+        }
         return encryptedContent;
       });
   },
@@ -231,10 +240,9 @@ const Board = SparkPlugin.extend({
         .then((res) => assign({
           device: this.spark.internal.device.deviceType,
           type: contentType,
-          encryptionKeyUrl,
-          payload: res.encryptedData
+          encryptionKeyUrl
         },
-          pick(res, `file`)
+          pick(res, `file`, `payload`)
         ));
     }));
   },
@@ -249,7 +257,7 @@ const Board = SparkPlugin.extend({
   encryptSingleContent(encryptionKeyUrl, content) {
     return this.spark.internal.encryption.encryptText(encryptionKeyUrl, JSON.stringify(content))
       .then((res) => ({
-        encryptedData: res,
+        payload: res,
         encryptionKeyUrl
       }));
   },
@@ -265,19 +273,22 @@ const Board = SparkPlugin.extend({
     return this.spark.internal.encryption.encryptScr(encryptionKeyUrl, content.file.scr)
       .then((encryptedScr) => {
         content.file.scr = encryptedScr;
-        return this.spark.internal.encryption.encryptText(encryptionKeyUrl, content.displayName);
+        if (content.displayName) {
+          content.metadata = assign(content.metadata, {displayName: content.displayName});
+        }
+        if (content.metadata) {
+          return this.spark.internal.encryption.encryptText(encryptionKeyUrl, JSON.stringify(content.metadata))
+            .then((encryptedMetadata) => {
+              content.metadata = encryptedMetadata;
+            });
+        }
+        return content;
       })
-      .then((encryptedDisplayName) => {
-        const metadata = {
-          displayName: encryptedDisplayName
-        };
-
-        return {
-          file: content.file,
-          encryptedData: JSON.stringify(metadata),
-          encryptionKeyUrl
-        };
-      });
+      .then(() => ({
+        file: content.file,
+        payload: content.metadata,
+        encryptionKeyUrl
+      }));
   },
 
   /**

--- a/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
@@ -176,7 +176,7 @@ const Board = SparkPlugin.extend({
    * @returns {Promise<Board~Content>}
    */
   decryptSingleFileContent(encryptionKeyUrl, encryptedContent) {
-    let metadata = ``;
+    let metadata;
 
     if (encryptedContent.payload) {
       metadata = encryptedContent.payload;
@@ -185,7 +185,10 @@ const Board = SparkPlugin.extend({
     return this.spark.internal.encryption.decryptScr(encryptionKeyUrl, encryptedContent.file.scr)
       .then((scr) => {
         encryptedContent.file.scr = scr;
-        return this.spark.internal.encryption.decryptText(encryptionKeyUrl, metadata);
+        if (metadata) {
+          return this.spark.internal.encryption.decryptText(encryptionKeyUrl, metadata);
+        }
+        return ``;
       })
       .then((decryptedMetadata) => {
         try {

--- a/packages/node_modules/@ciscospark/internal-plugin-board/src/index.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/src/index.js
@@ -39,9 +39,9 @@ registerInternalPlugin(`board`, Board, {
             return Promise.resolve(false);
           }
 
-          // we must have a payload
+          // we must have a payload or file
           /* istanbul ignore if */
-          if (!get(options, `body.items[0].payload`)) {
+          if (!get(options, `body.items[0].payload`) && !get(options, `body.items[0].file`)) {
             return Promise.resolve(false);
           }
           return Promise.resolve(true);

--- a/packages/node_modules/@ciscospark/internal-plugin-board/src/realtime.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/src/realtime.js
@@ -81,7 +81,7 @@ const RealtimeService = Mercury.extend({
       data: {
         eventType: `board.activity`,
         contentType,
-        payload: encryptedPayloadAndKeyUrl.encryptedData,
+        payload: encryptedPayloadAndKeyUrl.payload,
         envelope: {
           encryptionKeyUrl: encryptedPayloadAndKeyUrl.encryptionKeyUrl
         }
@@ -92,7 +92,7 @@ const RealtimeService = Mercury.extend({
     if (contentType === `FILE`) {
       data.data.payload = {
         file: encryptedPayloadAndKeyUrl.file,
-        payload: encryptedPayloadAndKeyUrl.encryptedData
+        payload: encryptedPayloadAndKeyUrl.payload
       };
     }
 

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
@@ -132,7 +132,7 @@ describe(`plugin-board`, () => {
       after(() => participants[0].spark.internal.board.deleteAllContent(board));
 
       it(`uploads image to spark files`, () => {
-        return participants[0].spark.internal.board.addImage(board, fixture)
+        return participants[0].spark.internal.board.addImage(board, fixture, {displayName: fixture.name})
           .then((fileContent) => {
             testContent = fileContent[0].items[0];
             assert.equal(testContent.type, `FILE`, `content type should be image`);
@@ -150,7 +150,7 @@ describe(`plugin-board`, () => {
             assert.isDefined(imageContent);
             assert.property(imageContent, `file`);
             assert.property(imageContent.file, `scr`);
-            assert.equal(imageContent.displayName, `sample-image-small-one.png`);
+            assert.equal(imageContent.metadata.displayName, `sample-image-small-one.png`);
             testScr = imageContent.file.scr;
             return imageContent.file.scr;
           });
@@ -167,7 +167,13 @@ describe(`plugin-board`, () => {
       });
     });
 
-    describe(`#getChannels`, () => {
+    // describe(`image contents with no payload`, () => {
+    //   it(``, () => {
+    //
+    //   });
+    // });
+
+    describe(`#getChannels()`, () => {
 
       it(`retrieves a newly created board for a specified conversation within a single page`, () => {
         return participants[0].spark.internal.board.getChannels(conversation)

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
@@ -211,6 +211,21 @@ describe(`plugin-board`, () => {
           });
       });
 
+      it(`retrieves annotated board`, () => {
+        let annotatedBoard;
+        return participants[0].spark.internal.board.createChannel(conversation, {type: `annotated`})
+          .then((res) => {
+            annotatedBoard = res;
+            return participants[0].spark.internal.board.getChannels(conversation, {type: `annotated`});
+          })
+          .then((getChannelsResp) => {
+            const channelFound = find(getChannelsResp.items, {channelId: annotatedBoard.channelId});
+            assert.isUndefined(find(getChannelsResp.items, {channelId: board.channelId}));
+            assert.isDefined(channelFound);
+            assert.notProperty(getChannelsResp.links, `next`);
+          });
+      });
+
       it(`retrieves all boards for a specified conversation across multiple pages`, () => {
         const numChannelsToAdd = 12;
         const pageLimit = 5;

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
@@ -138,6 +138,7 @@ describe(`plugin-board`, () => {
             assert.equal(testContent.type, `FILE`, `content type should be image`);
             assert.property(testContent, `contentUrl`, `content should contain contentId property`);
             assert.property(testContent, `channelUrl`, `content should contain contentUrl property`);
+            assert.property(testContent, `metadata`, `content should contain metadata property`);
             assert.property(testContent, `file`, `content should contain file property`);
             assert.property(testContent.file, `scr`, `content file should contain scr property`);
           });
@@ -165,13 +166,39 @@ describe(`plugin-board`, () => {
         return participants[2].spark.internal.encryption.download(testScr)
           .then((downloadedFile) => assert.becomes(fh.isMatchingFile(downloadedFile, fixture), true));
       });
-    });
 
-    // describe(`image contents with no payload`, () => {
-    //   it(``, () => {
-    //
-    //   });
-    // });
+      describe(`when image content has no metadata`, () => {
+        before(() => participants[0].spark.internal.board.deleteAllContent(board));
+
+        it(`decrypts no meta`, () => {
+          let testContent, testScr;
+          return participants[0].spark.internal.board.addImage(board, fixture)
+            .then((fileContent) => {
+              testContent = fileContent[0].items[0];
+              assert.equal(testContent.type, `FILE`, `content type should be image`);
+              assert.property(testContent, `contentUrl`, `content should contain contentId property`);
+              assert.property(testContent, `channelUrl`, `content should contain contentUrl property`);
+              assert.property(testContent, `file`, `content should contain file property`);
+              assert.property(testContent.file, `scr`, `content file should contain scr property`);
+              assert.deepEqual(testContent.metadata, {});
+
+              return participants[0].spark.internal.board.getContents(board);
+            })
+            .then((allContents) => {
+              const imageContent = find(allContents.items, {contentId: testContent.contentId});
+              assert.isDefined(imageContent);
+              assert.property(imageContent, `file`);
+              assert.property(imageContent.file, `scr`);
+              testScr = imageContent.file.scr;
+              return imageContent.file.scr;
+            })
+            .then(() => {
+              return participants[0].spark.internal.encryption.download(testScr)
+                .then((downloadedFile) => assert.becomes(fh.isMatchingFile(downloadedFile, fixture), true));
+            });
+        });
+      });
+    });
 
     describe(`#getChannels()`, () => {
 

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
@@ -393,7 +393,7 @@ describe(`plugin-board`, () => {
       return spark.internal.board.encryptContents(fakeURL, imageContents)
         .then(() => {
           assert.calledWith(spark.internal.encryption.encryptScr, fakeURL, {loc: fakeURL});
-          assert.calledWith(spark.internal.encryption.encryptText, fakeURL, `FileName`);
+          assert.calledWith(spark.internal.encryption.encryptText, fakeURL, JSON.stringify({displayName: `FileName`}));
         });
     });
 
@@ -464,7 +464,7 @@ describe(`plugin-board`, () => {
       return spark.internal.board.decryptContents(imageContents)
         .then(() => {
           assert.calledOnce(spark.internal.board.decryptSingleFileContent);
-          assert.calledWith(spark.internal.encryption.decryptText, fakeURL, `encryptedDisplayName`);
+          assert.calledWith(spark.internal.encryption.decryptText, fakeURL, JSON.stringify({type: `image`, displayName: `encryptedDisplayName`}));
           assert.calledWith(spark.internal.encryption.decryptScr, fakeURL, `encryptedScr`);
         });
     });
@@ -483,7 +483,7 @@ describe(`plugin-board`, () => {
       return spark.internal.board.decryptContents(imageContents)
         .then(() => {
           assert.calledOnce(spark.internal.board.decryptSingleFileContent);
-          assert.calledWith(spark.internal.encryption.decryptText, fakeURL, undefined);
+          assert.calledWith(spark.internal.encryption.decryptText, fakeURL, ``);
           assert.calledWith(spark.internal.encryption.decryptScr, fakeURL, `encryptedScr`);
         });
     });

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
@@ -483,7 +483,7 @@ describe(`plugin-board`, () => {
       return spark.internal.board.decryptContents(imageContents)
         .then(() => {
           assert.calledOnce(spark.internal.board.decryptSingleFileContent);
-          assert.calledWith(spark.internal.encryption.decryptText, fakeURL, ``);
+          assert.notCalled(spark.internal.encryption.decryptText);
           assert.calledWith(spark.internal.encryption.decryptScr, fakeURL, `encryptedScr`);
         });
     });


### PR DESCRIPTION
- image files now have no payload (to be consistent with other clients)
- if metadata is specified when `addImage` then payload will contain metadata
- `getChannels` now allows option `type` which can have values: whiteboard or annotated (by default if type is empty then server takes it as type `whiteboard`). 