### PR TITLE
feat(@ciscospark/internal-pulgin-metrics): support call diagnostic event

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-metrics/src/call-diagnostic-events-batcher.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-metrics/src/call-diagnostic-events-batcher.js
@@ -1,0 +1,43 @@
+/**!
+ *
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ * @private
+ */
+
+import Batcher from './batcher';
+
+const CallDiagnosticEventsBatcher = Batcher.extend({
+  namespace: `Metrics`,
+
+  prepareItem(item) {
+    // networkType should be a enum value: `wifi`, `ethernet`, `cellular`, or `unknown`.
+    // Browsers cannot provide such information right now. However, it is a required field.
+    const origin = {
+      buildType: process.env.NODE_ENV === `production` ? `prod` : `test`,
+      networkType: `unknown`
+    };
+    item.eventPayload.origin = Object.assign(origin, item.eventPayload.origin);
+    return Promise.resolve(item);
+  },
+
+  prepareRequest(queue) {
+    // Add sent timestamp
+    queue.forEach((item) => {
+      item.eventPayload.originTime.sent = new Date().toISOString();
+    });
+    return Promise.resolve(queue);
+  },
+
+  submitHttpRequest(payload) {
+    return this.spark.request({
+      method: `POST`,
+      service: `metrics`,
+      resource: `clientmetrics`,
+      body: {
+        metrics: payload
+      }
+    });
+  }
+});
+
+export default CallDiagnosticEventsBatcher;

--- a/packages/node_modules/@ciscospark/internal-plugin-metrics/src/metrics.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-metrics/src/metrics.js
@@ -7,12 +7,14 @@
 import {SparkPlugin} from '@ciscospark/spark-core';
 import Batcher from './batcher';
 import ClientMetricsBatcher from './client-metrics-batcher';
+import CallDiagnosticEventsBatcher from './call-diagnostic-events-batcher';
 import {deprecated} from '@ciscospark/common';
 
 const Metrics = SparkPlugin.extend({
   children: {
     batcher: Batcher,
-    clientMetricsBatcher: ClientMetricsBatcher
+    clientMetricsBatcher: ClientMetricsBatcher,
+    callDiagnosticEventsBatcher: CallDiagnosticEventsBatcher
   },
 
   namespace: `Metrics`,
@@ -91,8 +93,15 @@ const Metrics = SparkPlugin.extend({
         },
         body: payload
       }));
-  }
+  },
 
+  submitCallDiagnosticEvents(payload) {
+    const event = {
+      type: `diagnostic-event`,
+      eventPayload: payload
+    };
+    return this.callDiagnosticEventsBatcher.request(event);
+  }
 
 });
 

--- a/packages/node_modules/@ciscospark/internal-plugin-metrics/test/unit/spec/call-diagnostic-events-batcher.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-metrics/test/unit/spec/call-diagnostic-events-batcher.js
@@ -22,7 +22,7 @@ function promiseTick(count) {
 }
 
 describe(`plugin-metrics`, () => {
-  describe(`ClientMetricsBatcher`, () => {
+  describe(`callDiagnosticEventsBatcher`, () => {
     let spark;
 
     beforeEach(() => {
@@ -57,12 +57,17 @@ describe(`plugin-metrics`, () => {
       describe(`when the request completes successfully`, () => {
         it(`clears the queue`, () => {
           clock.uninstall();
-          return spark.internal.metrics.clientMetricsBatcher.request({
-            key: `testMetric`
+          return spark.internal.metrics.callDiagnosticEventsBatcher.request({
+            type: `diagnostic-event`,
+            eventPayload: {
+              originTime: {
+                triggered: `mock triggered timestamp`
+              }
+            }
           })
             .then(() => {
               assert.calledOnce(spark.request);
-              assert.lengthOf(spark.internal.metrics.clientMetricsBatcher.queue, 0);
+              assert.lengthOf(spark.internal.metrics.callDiagnosticEventsBatcher.queue, 0);
             });
         });
       });
@@ -96,12 +101,17 @@ describe(`plugin-metrics`, () => {
             });
           });
 
-          const promise = spark.internal.metrics.clientMetricsBatcher.request({
-            key: `testMetric`
+          const promise = spark.internal.metrics.callDiagnosticEventsBatcher.request({
+            type: `diagnostic-event`,
+            eventPayload: {
+              originTime: {
+                triggered: `mock triggered timestamp`
+              }
+            }
           });
 
           return promiseTick(50)
-            .then(() => assert.lengthOf(spark.internal.metrics.clientMetricsBatcher.queue, 1))
+            .then(() => assert.lengthOf(spark.internal.metrics.callDiagnosticEventsBatcher.queue, 1))
             .then(() => clock.tick(config.metrics.batcherWait))
             .then(() => assert.calledOnce(spark.request))
 
@@ -154,12 +164,12 @@ describe(`plugin-metrics`, () => {
             .then(() => assert.callCount(spark.request, 9))
 
             .then(() => promiseTick(50))
-            .then(() => assert.lengthOf(spark.internal.metrics.clientMetricsBatcher.queue, 0))
+            .then(() => assert.lengthOf(spark.internal.metrics.callDiagnosticEventsBatcher.queue, 0))
             .then(() => assert.isFulfilled(promise))
             .then(() => {
               assert.lengthOf(spark.request.args[1][0].body.metrics, 1, `Reenqueuing the metric once did not increase the number of metrics to be submitted`);
               assert.lengthOf(spark.request.args[2][0].body.metrics, 1, `Reenqueuing the metric twice did not increase the number of metrics to be submitted`);
-              assert.lengthOf(spark.internal.metrics.clientMetricsBatcher.queue, 0);
+              assert.lengthOf(spark.internal.metrics.callDiagnosticEventsBatcher.queue, 0);
             });
         });
       });

--- a/packages/node_modules/@ciscospark/internal-plugin-metrics/test/unit/spec/metrics.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-metrics/test/unit/spec/metrics.js
@@ -40,6 +40,11 @@ describe(`plugin-metrics`, () => {
         transformedProps
       ]
     };
+    const mockCallDiagnosticEvent = {
+      originTime: {
+        triggered: `mock triggered timestamp`
+      }
+    };
 
     beforeEach(() => {
       spark = new MockSpark({
@@ -61,6 +66,7 @@ describe(`plugin-metrics`, () => {
       sinon.spy(spark, `request`);
       sinon.spy(metrics, `postPreLoginMetric`);
       sinon.spy(metrics, `aliasUser`);
+      sinon.spy(metrics, `submitCallDiagnosticEvents`);
     });
 
     describe(`#submit()`, () => {
@@ -147,6 +153,23 @@ describe(`plugin-metrics`, () => {
             const params = req.qs;
 
             sinon.match(params, {alias: true});
+          });
+      });
+    });
+
+    describe(`#submitCallDiagnosticEvents()`, () => {
+      it(`submits a call diagnostic event`, () => {
+        return metrics.submitCallDiagnosticEvents(mockCallDiagnosticEvent)
+          .then(() => {
+            assert.calledOnce(spark.request);
+            const req = spark.request.args[0][0];
+            const metric = req.body.metrics[0];
+
+            assert.property(metric.eventPayload, `origin`);
+            assert.property(metric.eventPayload, `originTime`);
+            assert.property(metric.eventPayload.origin, `buildType`);
+            assert.property(metric.eventPayload.origin, `networkType`);
+            assert.property(metric.eventPayload.originTime, `sent`);
           });
       });
     });


### PR DESCRIPTION
Add a new function `submitCallDiagnosticEvents` in metrics plugin with callDiagnosticEventsBather to support of sending call diagnostic event to `/clientmetrics`.