### PR TITLE
Correct repo information for internal-plugin-board

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-board/package.json
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/package.json
@@ -6,7 +6,7 @@
   "author": "Greg Hewett <ghewett@cisco.com>",
   "main": "dist/index.js",
   "devMain": "src/index.js",
-  "repository": "https://github.com/ciscospark/spark-js-sdk/tree/master/packages/plugin-board",
+  "repository": "https://github.com/ciscospark/spark-js-sdk/tree/master/packages/node_modules/@ciscospark/internal-plugin-board",
   "engines": {
     "node": ">=4"
   },


### PR DESCRIPTION
Also, npm still thinks @ciscospark/plugin-board exists still, and uses this broken link too