### PR TITLE
fix(avatar): add defaultAvatar param and fetch all sizes of avatars

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-avatar/src/avatar-url-batcher.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-avatar/src/avatar-url-batcher.js
@@ -58,6 +58,7 @@ const AvatarUrlBatcher = Batcher.extend({
   handleItemSuccess(item) {
     return this.getDeferredForResponse(item)
       .then((defer) => defer.resolve({
+        hasDefaultAvatar: item.response.defaultAvatar,
         uuid: item.uuid,
         size: item.size,
         url: item.response.url}));

--- a/packages/node_modules/@ciscospark/internal-plugin-avatar/src/avatar-url-store.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-avatar/src/avatar-url-store.js
@@ -60,6 +60,7 @@ export default class AvatarUrlStore {
    * Adds the given item to the store
    * @param {Object} item
    * @param {integer} item.cacheControl
+   * @param {integer} item.hasDefaultAvatar
    * @param {integer} item.size
    * @param {string} item.url
    * @param {string} item.uuid

--- a/packages/node_modules/@ciscospark/internal-plugin-avatar/src/avatar.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-avatar/src/avatar.js
@@ -6,6 +6,7 @@
 
 import AvatarUrlBatcher from './avatar-url-batcher';
 import AvatarUrlStore from './avatar-url-store';
+import {oneFlight} from '@ciscospark/common';
 import {SparkPlugin} from '@ciscospark/spark-core';
 import {defaults} from 'lodash';
 
@@ -25,6 +26,14 @@ const Avatar = SparkPlugin.extend({
     }
   },
 
+  @oneFlight({keyFactory: (uuid) => uuid})
+  _fetchAllAvatarUrlSizes(uuid, options) {
+    // fetch all possible sizes of avatar and store in cache
+    return Promise.all(this.config.sizes.map((size) => this.batcher.request({uuid, size})
+      .then((item) => this.store.add(defaults({cacheControl: options.cacheControl}, item)))
+    ));
+  },
+
   /**
    * @private
    * Requests an avatar URL from the api
@@ -34,10 +43,16 @@ const Avatar = SparkPlugin.extend({
    * @param {integer} options.cacheControl
    * @returns {Promise<string>} the avatar URL
    */
+  @oneFlight({keyFactory: (uuid, options) => uuid + String(options && options.size)})
   _fetchAvatarUrl(uuid, options) {
     return this.store.get({uuid, size: options.size})
-      .catch(() => this.batcher.request({uuid, size: options.size}))
-        .then((item) => this.store.add(defaults({cacheControl: options.cacheControl}, item)));
+      .catch(() => Promise.all([
+        this._fetchAllAvatarUrlSizes(uuid, options),
+        // just in case options.size does not fall into the predefined values above
+        this.batcher.request({uuid, size: options.size})
+      ])
+        // eslint-disable-next-line no-unused-vars
+        .then(([ignore, item]) => this.store.add(defaults({cacheControl: options.cacheControl}, item))));
   },
 
   /**
@@ -47,6 +62,7 @@ const Avatar = SparkPlugin.extend({
    * @param {Object} [options]
    * @param {integer} [options.size] In {1600, 640, 192, 135, 110, 80, 50, 40}
    *                                 Defaults to 80 if falsy
+   * @param {boolean} [options.hideDefaultAvatar] does not return default avatar url if true. Defaults to false
    * @returns {Promise<string>} A promise that resolves to the avatar
    */
   retrieveAvatarUrl(user, options) {
@@ -61,7 +77,12 @@ const Avatar = SparkPlugin.extend({
 
     return this.spark.internal.user.asUUID(user)
       .then((uuid) => this._fetchAvatarUrl(uuid, options))
-      .then((item) => item.url);
+      .then((item) => {
+        if (options.hideDefaultAvatar) {
+          return item.hasDefaultAvatar ? null : item.url;
+        }
+        return item.url;
+      });
   },
 
   /**

--- a/packages/node_modules/@ciscospark/internal-plugin-avatar/src/config.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-avatar/src/config.js
@@ -19,6 +19,7 @@ export default {
      * @description default avatar size to retrieve if no size is specified
      * @type {number}
      */
-    defaultAvatarSize: 80
+    defaultAvatarSize: 80,
+    sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
   }
 };

--- a/packages/node_modules/@ciscospark/internal-plugin-avatar/test/unit/spec/avatar.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-avatar/test/unit/spec/avatar.js
@@ -9,7 +9,6 @@ import User from '@ciscospark/internal-plugin-user';
 import MockSpark from '@ciscospark/test-helper-mock-spark';
 import sinon from '@ciscospark/test-helper-sinon';
 
-
 describe(`plugin-avatar`, () => {
   let avatar;
   let spark;
@@ -28,6 +27,7 @@ describe(`plugin-avatar`, () => {
     avatar.config.defaultMaxAge = 60 * 60;
     avatar.config.defaultAvatarSize = 80;
     avatar.config.cacheControl = 3600;
+    avatar.config.sizes = [40, 50, 80, 110, 135, 192, 640, 1600];
   });
 
   describe(`#retrieveAvatarUrl()`, () => {
@@ -42,9 +42,44 @@ describe(`plugin-avatar`, () => {
         spark.request = sinon.stub().returns(Promise.resolve({
           body: {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -54,13 +89,13 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
         const deferred = avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`);
-        return assert.becomes(deferred, `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`);
+        return assert.becomes(deferred, `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`);
       });
 
       it(`fails to retrieve an avatar url`, () => {
@@ -90,9 +125,44 @@ describe(`plugin-avatar`, () => {
         spark.request = sinon.stub().returns(Promise.resolve({
           body: {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
               110: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -102,13 +172,13 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [110]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
 
-        return assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 110}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`);
+        return assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 110}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`);
       });
 
       it(`retrieves an avatar url for a non-standard size`, () => {
@@ -117,7 +187,47 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               35: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -127,13 +237,143 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [35]
+                sizes: [35, 40, 50, 80, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
 
-        return assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 35}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`);
+        return assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 35}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`);
+      });
+
+      describe(`when options.hideDefaultAvatar is true`, () => {
+        it(`returns null if it is a default avatar and options.hideDefaultAvatar is true`, () => {
+          spark.request = sinon.stub().returns(Promise.resolve({
+            body: {
+              '88888888-4444-4444-4444-aaaaaaaaaaa0': {
+                40: {
+                  size: 40,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                  cacheControl: `public max-age=3600`,
+                  defaultAvatar: true
+                },
+                50: {
+                  size: 50,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                  cacheControl: `public max-age=3600`,
+                  defaultAvatar: true
+                },
+                80: {
+                  size: 80,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                  cacheControl: `public max-age=3600`,
+                  defaultAvatar: true
+                },
+                110: {
+                  size: 110,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                  cacheControl: `public max-age=3600`,
+                  defaultAvatar: true
+                },
+                135: {
+                  size: 135,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                  cacheControl: `public max-age=3600`,
+                  defaultAvatar: true
+                },
+                192: {
+                  size: 192,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                  cacheControl: `public max-age=3600`,
+                  defaultAvatar: true
+                },
+                640: {
+                  size: 640,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                  cacheControl: `public max-age=3600`,
+                  defaultAvatar: true
+                },
+                1600: {
+                  size: 1600,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
+                  cacheControl: `public max-age=3600`,
+                  defaultAvatar: true
+                }
+              }
+            },
+            statusCode: 200,
+            options: {
+              body: [
+                {
+                  uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                  sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
+                }
+              ]
+            }
+          }));
+          const deferred = avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {hideDefaultAvatar: true});
+          return assert.becomes(deferred, null);
+        });
+
+        it(`retrieves avatar url if it is not a default avatar and options.hideDefaultAvatar is true`, () => {
+          spark.request = sinon.stub().returns(Promise.resolve({
+            body: {
+              '88888888-4444-4444-4444-aaaaaaaaaaa0': {
+                40: {
+                  size: 40,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                  cacheControl: `public max-age=3600`
+                },
+                50: {
+                  size: 50,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                  cacheControl: `public max-age=3600`
+                },
+                80: {
+                  size: 80,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                  cacheControl: `public max-age=3600`
+                },
+                110: {
+                  size: 110,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                  cacheControl: `public max-age=3600`
+                },
+                135: {
+                  size: 135,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                  cacheControl: `public max-age=3600`
+                },
+                192: {
+                  size: 192,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                  cacheControl: `public max-age=3600`
+                },
+                640: {
+                  size: 640,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                  cacheControl: `public max-age=3600`
+                },
+                1600: {
+                  size: 1600,
+                  url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
+                  cacheControl: `public max-age=3600`
+                }
+              }
+            },
+            statusCode: 200,
+            options: {
+              body: [
+                {
+                  uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                  sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
+                }
+              ]
+            }
+          }));
+          const deferred = avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {hideDefaultAvatar: true});
+          return assert.becomes(deferred, `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`);
+        });
       });
     });
 
@@ -142,16 +382,86 @@ describe(`plugin-avatar`, () => {
         spark.request = sinon.stub().returns(Promise.resolve({
           body: {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -161,19 +471,19 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
 
         return Promise.all([
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`)
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`)
         ])
           .then(() => {
             assert.callCount(spark.request, 1);
@@ -221,9 +531,44 @@ describe(`plugin-avatar`, () => {
         spark.request = sinon.stub().returns(Promise.resolve({
           body: {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -233,18 +578,18 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
 
         return Promise.all([
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`),
           assert.isRejected(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), /Failed to retrieve avatar/)
         ])
           .then(() => {
@@ -258,14 +603,84 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--40`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -275,19 +690,19 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [40]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`,
-                sizes: [40]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
 
         return Promise.all([
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--40`)
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~40`)
         ])
           .then(() => {
             assert.callCount(spark.request, 1);
@@ -300,14 +715,84 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`,
+                cacheControl: `public max-age=3600`
+              },
               110: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -317,19 +802,19 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [40]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`,
-                sizes: [110]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
 
         return Promise.all([
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 110}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`)
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 110}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`)
         ])
           .then(() => {
             assert.callCount(spark.request, 1);
@@ -342,19 +827,84 @@ describe(`plugin-avatar`, () => {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
               40: {
                 size: 40,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--40`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`,
                 cacheControl: `public max-age=3600`
               },
               110: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -364,20 +914,20 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [40]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`,
-                sizes: [40, 110]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
 
         return Promise.all([
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--40`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--40`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 110}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`)
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 40}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~40`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 110}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`)
         ])
           .then(() => {
             assert.callCount(spark.request, 1);
@@ -388,16 +938,96 @@ describe(`plugin-avatar`, () => {
         spark.request = sinon.stub().returns(Promise.resolve({
           body: {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
               100: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--110`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~50`,
+                cacheControl: `public max-age=3600`
+              },
+              80: {
+                size: 80,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`,
+                cacheControl: `public max-age=3600`
+              },
               100: {
                 size: 110,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -407,19 +1037,19 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [100]
+                sizes: [40, 50, 80, 100, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`,
-                sizes: [100]
+                sizes: [40, 50, 80, 100, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
 
         return Promise.all([
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 100}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0--110`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 100}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1--110`)
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`, {size: 100}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`, {size: 100}), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`)
         ])
           .then(() => {
             assert.callCount(spark.request, 1);
@@ -431,44 +1061,254 @@ describe(`plugin-avatar`, () => {
         spark.request = sinon.stub().returns(Promise.resolve({
           body: {
             '88888888-4444-4444-4444-aaaaaaaaaaa0': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa1': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa2': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa3': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa4': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~1600`,
                 cacheControl: `public max-age=3600`
               }
             },
             '88888888-4444-4444-4444-aaaaaaaaaaa5': {
+              40: {
+                size: 40,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5~40`,
+                cacheControl: `public max-age=3600`
+              },
+              50: {
+                size: 50,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5~50`,
+                cacheControl: `public max-age=3600`
+              },
               80: {
                 size: 80,
-                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5`,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5~80`,
+                cacheControl: `public max-age=3600`
+              },
+              110: {
+                size: 110,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5~110`,
+                cacheControl: `public max-age=3600`
+              },
+              135: {
+                size: 135,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5~135`,
+                cacheControl: `public max-age=3600`
+              },
+              192: {
+                size: 192,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5~192`,
+                cacheControl: `public max-age=3600`
+              },
+              640: {
+                size: 640,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5~640`,
+                cacheControl: `public max-age=3600`
+              },
+              1600: {
+                size: 1600,
+                url: `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5~1600`,
                 cacheControl: `public max-age=3600`
               }
             }
@@ -478,54 +1318,54 @@ describe(`plugin-avatar`, () => {
             body: [
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa0`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa1`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa2`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa3`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa4`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               },
               {
                 uuid: `88888888-4444-4444-4444-aaaaaaaaaaa5`,
-                sizes: [80]
+                sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
               }
             ]
           }
         }));
         return Promise.all([
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa3`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa3`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~80`),
 
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa3`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0`),
-          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa5`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5`)
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa2`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa2~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa3`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa3~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa1`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa1~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa4`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa4~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa0`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa0~80`),
+          assert.becomes(avatar.retrieveAvatarUrl(`88888888-4444-4444-4444-aaaaaaaaaaa5`), `https://example.com/88888888-4444-4444-4444-aaaaaaaaaaa5~80`)
         ])
           .then(() => {
             assert.callCount(spark.request, 1);


### PR DESCRIPTION
This PR exposes whether an avatar is a default avatar or not. Also, when an avatar is requested, it fetches all sizes of the avatar and stores them into the cache so that they will all match when different sizes are fetched and expire the same time