### PR TITLE
API Documentation Updates

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-people/src/people.js
+++ b/packages/node_modules/@ciscospark/plugin-people/src/people.js
@@ -9,10 +9,10 @@ import PeopleBatcher from './people-batcher';
 
 /**
  * @typedef {Object} PersonObject
- * @property {uuid} id - Unique identifier for the person
+ * @property {string} id - (server generated) Unique identifier for the person
  * @property {Array<email>} emails - Email addresses of the person
  * @property {string} displayName - Display name of the person
- * @property {isoDate} created - The date and time that the person was created
+ * @property {isoDate} created - (server generated) The date and time that the person was created
  */
 
 /**

--- a/packages/node_modules/ciscospark/src/ciscospark.js
+++ b/packages/node_modules/ciscospark/src/ciscospark.js
@@ -51,7 +51,7 @@ const CiscoSpark = SparkCore.extend({
 CiscoSpark.version = PACKAGE_VERSION;
 
 /**
- * Create a new CiscoSpark instance
+ * Create a new {@link CiscoSpark} instance
  *
  * @example
  * <caption>Create a new CiscoSpark instance configured for your OAuth client</caption>

--- a/packages/node_modules/ciscospark/src/ciscospark.js
+++ b/packages/node_modules/ciscospark/src/ciscospark.js
@@ -51,7 +51,7 @@ const CiscoSpark = SparkCore.extend({
 CiscoSpark.version = PACKAGE_VERSION;
 
 /**
- * Create a new ciscospark instance
+ * Create a new CiscoSpark instance
  *
  * @example
  * <caption>Create a new CiscoSpark instance configured for your OAuth client</caption>

--- a/packages/node_modules/ciscospark/src/index.js
+++ b/packages/node_modules/ciscospark/src/index.js
@@ -9,3 +9,15 @@ if (!global._babelPolyfill) {
 }
 
 module.exports = require(`./ciscospark`);
+
+ /**
+ * The date and time, specified in ISO 8601 extended offset date/time
+ * format (e.g. `2015-10-18T14:26:16+00:00`).
+ *
+ * @typedef {string} isoDate
+ */
+
+ /**
+ * An email address, as a string.
+ * @typedef {string} email
+ */

--- a/packages/node_modules/ciscospark/src/plugins/memberships.js
+++ b/packages/node_modules/ciscospark/src/plugins/memberships.js
@@ -6,22 +6,27 @@ import {SparkPlugin, Page} from '@ciscospark/spark-core';
 
 /**
  * @typedef {Object} MembershipObject
- * @property {uuid} id - Unique identifier for the membership
+ * @property {string} id - Unique identifier for the membership
  * @property {string} roomId - The room ID
- * @property {uuid} personId - The person ID
+ * @property {string} personId - The person ID
  * @property {email} personEmail - The email address of the person / room member
- * @property {boolean} isModerator - Indicates whether the specified person should be a room moderator.
- * @property {boolean} isMonitor - Indicates whether the specified member is a room monitor.
- * @property {isoDate} created - The date and time that this membership was created.
+ * @property {boolean} isModerator - Indicates whether the specified person should be a room moderator
+ * @property {boolean} isMonitor - Indicates whether the specified member is a room monitor
+ * @property {isoDate} created - The date and time that this membership was created
  */
 
 /**
+ * Memberships represent a person's relationship to a room. Use this API to list
+ * members of any room that you're in or create memberships to invite someone
+ * to a room. Memberships can also be updated to make someone a moderator
+ * or deleted to remove them from the room.
  * @class
+ * @name Memberships
  */
 const Memberships = SparkPlugin.extend({
   /**
-   * Adds a person to a room. The person can be added by ID (personId) or by
-   * Email Address (personEmail). The person can be optionally added to the room
+   * Adds a person to a room. The person can be added by ID (`personId`) or by
+   * Email Address (`personEmail`). The person can be optionally added to the room
    * as a moderator.
    * @instance
    * @memberof Memberships

--- a/packages/node_modules/ciscospark/src/plugins/messages.js
+++ b/packages/node_modules/ciscospark/src/plugins/messages.js
@@ -7,20 +7,24 @@ import {isArray} from 'lodash';
 
 /**
  * @typedef {Object} MessageObject
- * @property {uuid} id - (server generated) Unique identifier for the message
- * @property {uuid} personId - The ID for the author of the messasge
+ * @property {string} id - (server generated) Unique identifier for the message
+ * @property {string} personId - The ID for the author of the messasge
  * @property {email} personEmail - The email for the author of the messasge
- * @property {string} roomId - The message posted to the room in plain text
- * @property {isoDate} created - (server generated)The source URLs for the
- * message attachment. See the {@link Content & Attachments{ Guide for a list of
- * supported media types.
+ * @property {string} roomId - The ID for the room of the message
+ * @property {string} text - The message posted to the room in plain text
+ * @property {string} markdown - The message posted to the room in markdown
+ * @property {Array<string>} files - The source URL(s) for the message attachment(s).
+ * See the {@link https://developer.ciscospark.com/attachments.html|Message Attachments}
+ * Guide for a list of supported media types.
+ * @property {isoDate} created - (server generated) The date and time that the message was created
  */
 
 /**
  * Messages are how people communicate in rooms. Each message timestamped and
  * represented in Spark as a distinct block of content. Messages can contain
  * plain text and a single file attachment. See the
- * {@link Message Attachments Guide} for a list of supported media types.
+ * {@link https://developer.ciscospark.com/attachments.html|Message Attachments} Guide
+ * for a list of supported media types.
  * @class
  */
 const Messages = SparkPlugin.extend({

--- a/packages/node_modules/ciscospark/src/plugins/rooms.js
+++ b/packages/node_modules/ciscospark/src/plugins/rooms.js
@@ -9,26 +9,25 @@ import {SparkPlugin, Page} from '@ciscospark/spark-core';
  * @property {string} id - (server generated) Unique identifier for the room
  * @property {string} title - The display name for the room. All room members
  * will see the title so make it something good
+ * @property {string} teamId - (optional) The ID of the team to which the room
+ * belongs
  * @property {isoDate} created - (server generated) The date and time that the
  * room was created
- * @property {string} teamId - (optional): The id of the team to which the room
- * belongs
  */
 
 /**
  * Rooms are virtual meeting places for getting stuff done. This resource
- * represents the room itself. Check out the Memberships API to learn how to add
- * and remove people from rooms and the Messages API for posting and managing
- * content.
+ * represents the room itself. Check out the {@link Memberships} API to learn
+ * how to add and remove people from rooms and the {@link Messages} API for
+ * posting and managing content.
  * @class
  * @name Rooms
  */
 const Rooms = SparkPlugin.extend({
   /**
    * Creates a new room. The authenticated user is automatically added as a
-   * member of the room. See the @{link Memberships} to learn how to add more
-   * people to the room.
-   * {@link Membership}
+   * member of the room. See the {@link Memberships} API to learn how to add
+   * more people to the room.
    * @instance
    * @memberof Rooms
    * @param {RoomObject} room

--- a/packages/node_modules/ciscospark/src/plugins/team-memberships.js
+++ b/packages/node_modules/ciscospark/src/plugins/team-memberships.js
@@ -6,11 +6,13 @@ import {SparkPlugin, Page} from '@ciscospark/spark-core';
 
 /**
  * @typedef {Object} TeamMembershipObject
- * @property {string} id - (server generated) The team ID
+ * @property {string} id - (server generated) Unique identifier for the team membership
+ * @property {string} teamId - The team ID
  * @property {string} personId - The person ID
  * @property {string} personEmail - The email address of the person
  * @property {boolean} isModerator - Set to `true` to make the person a team
  * moderator
+ * @property {string} created - (server generated) The date and time that the team membership was created
  */
 
 /**

--- a/packages/node_modules/ciscospark/src/plugins/teams.js
+++ b/packages/node_modules/ciscospark/src/plugins/teams.js
@@ -6,10 +6,10 @@ import {SparkPlugin, Page} from '@ciscospark/spark-core';
 
 /**
  * @typedef {Object} TeamObject
- * @property {string} id - (server generated) The unique ID for the team.
- * @property {string} name - The name of the team.
- * @property {isoDate} created - (server generated) The date and time when the
- * team was created, in ISO8601 format.
+ * @property {string} id - (server generated) Unique identifier for the team
+ * @property {string} name - The name of the team
+ * @property {isoDate} created - (server generated) The date and time that the
+ * team was created
  */
 
 /**

--- a/packages/node_modules/ciscospark/src/plugins/webhooks.js
+++ b/packages/node_modules/ciscospark/src/plugins/webhooks.js
@@ -6,17 +6,19 @@ import {SparkPlugin, Page} from '@ciscospark/spark-core';
 
 /**
  * @typedef {Object} WebhookObject
- * @property {string} id - The unique ID for the webhook.
- * @property {string} resource - The resource type for the webhook.
- * @property {string} event - The event type for the webhook.
- * @property {string} filter - The filter that defines the webhook scope.
- * @property {string} targetUrl - The URL that receives POST requests for each event.
- * @property {string} name - A user-friendly name for this webhook.
+ * @property {string} id - (server generated) Unique identifier for the webhook
+ * @property {string} resource - The resource type for the webhook
+ * @property {string} event - The event type for the webhook
+ * @property {string} filter - The filter that defines the webhook scope
+ * @property {string} targetUrl - The URL that receives POST requests for each event
+ * @property {string} name - A user-friendly name for this webhook
+ * @property {string} created - (server generated) The date and time that the webhook was created
  */
 
 /**
- * A webhook notifies an application when an event for which the application is
- * registered has occurred.
+ * Webhooks allow your app to be notified via HTTP when a specific event
+ * occurs on Spark. For example, your app can register a webhook to be
+ * notified when a new message is posted into a specific room.
  * @class
  */
 const Webhooks = SparkPlugin.extend({


### PR DESCRIPTION
- Standardize wording across objects
- Add `text`/`markdown` properties to `MessageObject` (closes #680)
- Change several property types from `uuid` to `string`
- Correct several `@link` links