### PR TITLE
feat(@ciscospark/internal-plugin-conversation): set/unset space property

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -994,6 +994,36 @@ const Conversation = SparkPlugin.extend({
   };
 });
 
+/**
+ * Sets/unsets space property for convo
+ * @param {Object} conversation
+ * @param {string} tag
+ * @param {Activity} activity
+ * @returns {Promise<Activity>}
+ */
+[
+  `setSpaceProperty`,
+  `unsetSpaceProperty`
+].forEach((fnName) => {
+  const verb = fnName.startsWith(`set`) ? `set` : `unset`;
+  Conversation.prototype[fnName] = function submitSpacePropertyActivity(conversation, tag, activity) {
+    if (!isString(tag)) {
+      return Promise.reject(new Error(`\`tag\` must be a string`));
+    }
+
+    return this._inferConversationUrl(conversation)
+      .then(() => this.prepare(activity, {
+        verb,
+        target: this.prepareConversation(conversation),
+        object: {
+          tags: [tag],
+          objectType: `spaceProperty`
+        }
+      }))
+      .then((a) => this.submit(a));
+  };
+});
+
 [
   `tag`,
   `untag`

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/verbs.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/verbs.js
@@ -535,6 +535,61 @@ describe(`plugin-conversation`, function() {
         });
       });
 
+      describe(`#setSpaceProperty()`, () => {
+        afterEach(() => {conversation = null;});
+        describe(`when the current user is a moderator`, () => {
+          it(`sets announcement mode for the specified conversation`, () => spark.internal.conversation.assignModerator(conversation)
+            .catch(allowConflicts)
+            .then(() => spark.internal.conversation.lock(conversation))
+            .catch(allowConflicts)
+            .then(() => spark.internal.conversation.setSpaceProperty(conversation, `ANNOUNCEMENT`))
+            .then((activity) => {
+              assert.isActivity(activity);
+            })
+            .then(() => spark.internal.conversation.get(conversation))
+            .then((c) => assert.include(c.tags, `ANNOUNCEMENT`)));
+        });
+
+        describe(`when the current user is not a moderator`, () => {
+          it(`fails to set announcement mode for the specified conversation`, () => spark.internal.conversation.assignModerator(conversation)
+            .catch(allowConflicts)
+            .then(() => spark.internal.conversation.lock(conversation))
+            .catch(allowConflicts)
+            .then(() => assert.isRejected(mccoy.spark.internal.conversation.setSpaceProperty(conversation, `ANNOUNCEMENT`)))
+            .then((reason) => assert.instanceOf(reason, SparkHttpError.Forbidden)));
+        });
+      });
+
+      describe(`#unsetSpaceProperty()`, () => {
+        afterEach(() => {conversation = null;});
+        describe(`when the current user is a moderator`, () => {
+          it(`unsets announcement mode for the specified conversation`, () => spark.internal.conversation.assignModerator(conversation)
+            .catch(allowConflicts)
+            .then(() => spark.internal.conversation.lock(conversation))
+            .catch(allowConflicts)
+            .then(() => spark.internal.conversation.setSpaceProperty(conversation, `ANNOUNCEMENT`))
+            .then((activity) => {
+              assert.isActivity(activity);
+            })
+            .then(() => spark.internal.conversation.unsetSpaceProperty(conversation, `ANNOUNCEMENT`))
+            .then(() => spark.internal.conversation.get(conversation))
+            .then((c) => assert.notInclude(c.tags, `ANNOUNCEMENT`)));
+        });
+
+        describe(`when the current user is not a moderator`, () => {
+          it(`fails to unset announcement mode for the specified conversation`, () => spark.internal.conversation.assignModerator(conversation)
+            .catch(allowConflicts)
+            .then(() => spark.internal.conversation.lock(conversation))
+            .catch(allowConflicts)
+            .then(() => spark.internal.conversation.setSpaceProperty(conversation, `ANNOUNCEMENT`))
+            .then((activity) => {
+              assert.isActivity(activity);
+            })
+            .then(() => assert.isRejected(mccoy.spark.internal.conversation.unsetSpaceProperty(conversation, `ANNOUNCEMENT`)))
+            .then((reason) => assert.instanceOf(reason, SparkHttpError.Forbidden)));
+        });
+      });
+
       describe(`#removeAllMuteTags()`, () => {
         it(`removes all mute tags on the convo`, () => {
           return spark.internal.conversation.muteMessages(conversation)


### PR DESCRIPTION
Add ability to set/unset ANNOUNCEMENT tag to conversations.
https://sqbu-github.cisco.com/WebExSquared/cloud-apps/wiki/Announcement-Only-Spaces-Design