### PR TITLE
fix(@ciscospark/common): remove console logging

### DIFF
--- a/packages/node_modules/@ciscospark/common/src/one-flight.js
+++ b/packages/node_modules/@ciscospark/common/src/one-flight.js
@@ -58,10 +58,11 @@ export default function oneFlight(...params) {
         if (this && this.logger) {
           this.logger.info(message);
         }
-        else {
-          /* eslint no-console: [0] */
+        else if (process.env.NODE_ENV !== `production`) {
+          // eslint-disable-next-line no-console
           console.info(message);
         }
+
         return flight;
       }
 


### PR DESCRIPTION
`logger` should be console if nothing else is defined.