### PR TITLE
feat(@ciscospark/i-p-board): prevent deletion of active whiteboard

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
@@ -173,7 +173,10 @@ const Board = SparkPlugin.extend({
   lockChannelForDeletion(channel) {
     return this.spark.request({
       method: `POST`,
-      uri: `${channel.channelUrl}/lock?intent=delete`
+      uri: `${channel.channelUrl}/lock`,
+      qs: {
+        intent: `delete`
+      }
     })
       .then((res) => res.body);
   },

--- a/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
@@ -132,9 +132,11 @@ const Board = SparkPlugin.extend({
    * @memberof Board.BoardService
    * @param  {Conversation~ConversationObject} conversation
    * @param  {Board~Channel} channel
+   * @param  {Object} options
+   * @param  {Object} options.preventDeleteActiveChannel Returns error if channel is in use
    * @returns {Promise}
    */
-  deleteChannel(conversation, channel) {
+  deleteChannel(conversation, channel, options = {}) {
     // remove the ACL link between conversation and board
     // remove conversation auth from board KRO in kms message
     const body = {
@@ -147,10 +149,31 @@ const Board = SparkPlugin.extend({
       aclLinkOperation: `DELETE`
     };
 
+    let promise = Promise.resolve();
+    if (options.preventDeleteActiveChannel) {
+      promise = this.lockChannelForDeletion(channel);
+    }
+
+    return promise
+      .then(() => this.spark.request({
+        method: `PUT`,
+        uri: `${channel.aclUrl}/links`,
+        body
+      }))
+      .then((res) => res.body);
+  },
+
+  /**
+   * Locks and marks a channel for deletion
+   * If a channel is being used, it will return 409 - Conflict
+   * @memberof Board.BoardService
+   * @param  {Board~Channel} channel
+   * @returns {Promise}
+   */
+  lockChannelForDeletion(channel) {
     return this.spark.request({
-      method: `PUT`,
-      uri: `${channel.aclUrl}/links`,
-      body
+      method: `POST`,
+      uri: `${channel.channelUrl}/lock?intent=delete`
     })
       .then((res) => res.body);
   },

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
@@ -517,14 +517,14 @@ describe(`plugin-board`, () => {
             .then(() => assert.isFulfilled(participants[1].spark.internal.board.getChannel(activeChannel)));
         });
 
-        it(`deletes non-active channel`, () => {
-          let nonActiveChannel;
+        it(`deletes inactive channel`, () => {
+          let inActiveChannel;
           return participants[1].spark.internal.board.createChannel(conversation)
             .then((res) => {
-              nonActiveChannel = res;
-              return participants[1].spark.internal.board.deleteChannel(conversation, nonActiveChannel, {preventDeleteActiveChannel: true});
+              inActiveChannel = res;
+              return participants[1].spark.internal.board.deleteChannel(conversation, inActiveChannel, {preventDeleteActiveChannel: true});
             })
-            .then(() => assert.isRejected(participants[1].spark.internal.board.getChannel(nonActiveChannel)));
+            .then(() => assert.isRejected(participants[1].spark.internal.board.getChannel(inActiveChannel)));
         });
       });
     });

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
@@ -499,6 +499,52 @@ describe(`plugin-board`, () => {
             return assert.isRejected(participants[1].spark.internal.board.getChannel(newChannel));
           });
       });
+
+      describe(`when preventDeleteActiveChannel is enabled`, () => {
+        it(`does not delete when a channel is being used`, () => {
+          let activeChannel;
+          return participants[1].spark.internal.board.createChannel(conversation)
+            .then((res) => {
+              activeChannel = res;
+              const data = [{
+                type: `curve`,
+                payload: JSON.stringify({type: `curve`})
+              }];
+              // this will mark the channel as being used
+              return participants[0].spark.internal.board.addContent(activeChannel, data);
+            })
+            .then(() => assert.isRejected(participants[1].spark.internal.board.deleteChannel(conversation, activeChannel, {preventDeleteActiveChannel: true})))
+            .then(() => assert.isFulfilled(participants[1].spark.internal.board.getChannel(activeChannel)));
+        });
+
+        it(`deletes non-active channel`, () => {
+          let nonActiveChannel;
+          return participants[1].spark.internal.board.createChannel(conversation)
+            .then((res) => {
+              nonActiveChannel = res;
+              return participants[1].spark.internal.board.deleteChannel(conversation, nonActiveChannel, {preventDeleteActiveChannel: true});
+            })
+            .then(() => assert.isRejected(participants[1].spark.internal.board.getChannel(nonActiveChannel)));
+        });
+      });
+    });
+
+    describe(`#lockChannelForDeletion()`, () => {
+      it(`locks a channel for deletion which rejects any incoming activities`, () => {
+        let newChannel;
+        return participants[1].spark.internal.board.createChannel(conversation)
+          .then((res) => {
+            newChannel = res;
+            return participants[1].spark.internal.board.lockChannelForDeletion(newChannel);
+          })
+          .then(() => {
+            const data = [{
+              type: `curve`,
+              payload: JSON.stringify({type: `curve`})
+            }];
+            return assert.isRejected(participants[0].spark.internal.board.addContent(newChannel, data));
+          });
+      });
     });
   });
 

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
@@ -254,7 +254,10 @@ describe(`plugin-board`, () => {
         .then(() => {
           assert.calledWith(spark.request, sinon.match({
             method: `POST`,
-            uri: `${channel.channelUrl}/lock?intent=delete`
+            uri: `${channel.channelUrl}/lock`,
+            qs: {
+              intent: `delete`
+            }
           }));
 
           assert.calledWith(spark.request, sinon.match({
@@ -281,7 +284,10 @@ describe(`plugin-board`, () => {
         .then(() => {
           assert.calledWith(spark.request, sinon.match({
             method: `POST`,
-            uri: `${channel.channelUrl}/lock?intent=delete`
+            uri: `${channel.channelUrl}/lock`,
+            qs: {
+              intent: `delete`
+            }
           }));
         });
     });

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
@@ -247,6 +247,44 @@ describe(`plugin-board`, () => {
           }));
         });
     });
+
+    it(`requests locks channel before delete when preventDeleteActiveChannel is enabled`, () => {
+      spark.request.reset();
+      return spark.internal.board.deleteChannel(conversation, channel, {preventDeleteActiveChannel: true})
+        .then(() => {
+          assert.calledWith(spark.request, sinon.match({
+            method: `POST`,
+            uri: `${channel.channelUrl}/lock?intent=delete`
+          }));
+
+          assert.calledWith(spark.request, sinon.match({
+            method: `PUT`,
+            uri: `${channel.aclUrl}/links`,
+            body: {
+              aclLinkType: `INCOMING`,
+              linkedAcl: conversation.aclUrl,
+              kmsMessage: {
+                method: `delete`,
+                uri: `${channel.kmsResourceUrl}/authorizations?${querystring.stringify({authId: conversation.kmsResourceObjectUrl})}`
+              },
+              aclLinkOperation: `DELETE`
+            }
+          }));
+        });
+    });
+  });
+
+  describe(`#lockChannelForDeletion()`, () => {
+    it(`requests POST with delete lock intent`, () => {
+      spark.request.reset();
+      return spark.internal.board.lockChannelForDeletion(channel)
+        .then(() => {
+          assert.calledWith(spark.request, sinon.match({
+            method: `POST`,
+            uri: `${channel.channelUrl}/lock?intent=delete`
+          }));
+        });
+    });
   });
 
   describe(`#deleteAllContent()`, () => {
@@ -392,191 +430,6 @@ describe(`plugin-board`, () => {
 
     it(`has a child of realtime`, () => {
       assert.isDefined(spark.internal.board.realtime);
-    });
-  });
-
-  describe(`#encryptContents`, () => {
-
-    before(() => {
-      sinon.stub(spark.internal.board, `encryptSingleContent`).returns(Promise.resolve({
-        encryptedData,
-        encryptionKeyUrl: fakeURL
-      }));
-    });
-
-    afterEach(() => {
-      spark.internal.board.encryptSingleContent.reset();
-    });
-
-    it(`calls encryptSingleContent when type is not image`, () => {
-
-      const curveContents = [{
-        type: `curve`
-      }];
-
-      return spark.internal.board.encryptContents(fakeURL, curveContents)
-        .then(() => {
-          assert.calledWith(spark.internal.board.encryptSingleContent, fakeURL, curveContents[0]);
-          assert.notCalled(spark.internal.encryption.encryptScr);
-        });
-    });
-
-    it(`calls encryptText and encryptScr when scr is found in content`, () => {
-
-      const imageContents = [{
-        displayName: `FileName`,
-        file: {
-          scr: {
-            loc: fakeURL
-          }
-        }
-      }];
-
-      return spark.internal.board.encryptContents(fakeURL, imageContents)
-        .then(() => {
-          assert.calledWith(spark.internal.encryption.encryptScr, fakeURL, {loc: fakeURL});
-          assert.calledWith(spark.internal.encryption.encryptText, fakeURL, JSON.stringify({displayName: `FileName`}));
-        });
-    });
-
-    it(`sets the device to config deviceType`, () => {
-      const curveContents = [{
-        type: `curve`
-      }];
-
-      return spark.internal.board.encryptContents(fakeURL, curveContents)
-        .then((res) => {
-          assert.equal(res[0].device, `FAKE_DEVICE`);
-        });
-    });
-  });
-
-  describe(`#decryptContents`, () => {
-
-    before(() => {
-      sinon.stub(spark.internal.board, `decryptSingleContent`, sinon.stub().returns(Promise.resolve({})));
-      sinon.spy(spark.internal.board, `decryptSingleFileContent`);
-    });
-
-    after(() => {
-      spark.internal.board.decryptSingleContent.restore();
-      spark.internal.board.decryptSingleFileContent.restore();
-    });
-
-    afterEach(() => {
-      spark.internal.board.decryptSingleContent.reset();
-      spark.internal.board.decryptSingleFileContent.reset();
-      spark.internal.encryption.decryptScr.reset();
-      spark.internal.encryption.decryptText.reset();
-    });
-
-    it(`calls decryptSingleContent when type is not image`, () => {
-
-      const curveContents = {
-        items: [{
-          type: `STRING`,
-          payload: encryptedData,
-          encryptionKeyUrl: fakeURL
-        }]
-      };
-
-      return spark.internal.board.decryptContents(curveContents)
-        .then(() => {
-          assert.calledWith(spark.internal.board.decryptSingleContent, fakeURL, encryptedData);
-          assert.notCalled(spark.internal.encryption.decryptScr);
-          assert.notCalled(spark.internal.encryption.decryptText);
-        });
-    });
-
-    it(`calls decryptSingleFileContent when type is FILE`, () => {
-      const imageContents = {
-        items: [{
-          type: `FILE`,
-          payload: JSON.stringify({
-            type: `image`,
-            displayName: `encryptedDisplayName`
-          }),
-          file: {
-            scr: `encryptedScr`
-          },
-          encryptionKeyUrl: fakeURL
-        }]
-      };
-
-      return spark.internal.board.decryptContents(imageContents)
-        .then(() => {
-          assert.calledOnce(spark.internal.board.decryptSingleFileContent);
-          assert.calledWith(spark.internal.encryption.decryptText, fakeURL, JSON.stringify({type: `image`, displayName: `encryptedDisplayName`}));
-          assert.calledWith(spark.internal.encryption.decryptScr, fakeURL, `encryptedScr`);
-        });
-    });
-
-    it(`does not require payload when type is FILE`, () => {
-      const imageContents = {
-        items: [{
-          type: `FILE`,
-          file: {
-            scr: `encryptedScr`
-          },
-          encryptionKeyUrl: fakeURL
-        }]
-      };
-
-      return spark.internal.board.decryptContents(imageContents)
-        .then(() => {
-          assert.calledOnce(spark.internal.board.decryptSingleFileContent);
-          assert.notCalled(spark.internal.encryption.decryptText);
-          assert.calledWith(spark.internal.encryption.decryptScr, fakeURL, `encryptedScr`);
-        });
-    });
-
-    it(`decrypts FILE metadata displayName`, () => {
-      const imageContentsWithMetadata = {
-        items: [{
-          type: `FILE`,
-          payload: JSON.stringify({
-            type: `image`,
-            displayName: `encryptedDisplayName`
-          }),
-          file: {
-            scr: `encryptedScr`
-          },
-          encryptionKeyUrl: fakeURL
-        }]
-      };
-      spark.internal.encryption.decryptText.onFirstCall().returns(JSON.stringify({displayName: `decryptedDisplayName`}));
-      return spark.internal.board.decryptContents(imageContentsWithMetadata)
-        .then((contents) => {
-          assert.calledOnce(spark.internal.board.decryptSingleFileContent);
-          assert.calledWith(spark.internal.encryption.decryptScr, fakeURL, `encryptedScr`);
-          assert.calledWith(spark.internal.encryption.decryptText, fakeURL, JSON.stringify({type: `image`, displayName: `encryptedDisplayName`}));
-          assert.equal(contents[0].metadata.displayName, `decryptedDisplayName`);
-        });
-    });
-
-    it(`assigns FILE payload metadata to decrypted file`, () => {
-      const imageContentsWithMetadata = {
-        items: [{
-          type: `FILE`,
-          payload: JSON.stringify({
-            type: `image`,
-            size: 123
-          }),
-          file: {
-            scr: `encryptedScr`
-          },
-          encryptionKeyUrl: fakeURL
-        }]
-      };
-      spark.internal.encryption.decryptText.onFirstCall().returns(JSON.stringify({type: `image`, size: 123}));
-      return spark.internal.board.decryptContents(imageContentsWithMetadata)
-        .then((contents) => {
-          assert.calledOnce(spark.internal.board.decryptSingleFileContent);
-          assert.deepEqual(contents[0].metadata, {
-            type: `image`,
-            size: 123
-          });
-        });
     });
   });
 

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/encryption.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/encryption.js
@@ -1,0 +1,230 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {assert} from '@ciscospark/test-helper-chai';
+import MockSpark from '@ciscospark/test-helper-mock-spark';
+import sinon from '@ciscospark/test-helper-sinon';
+import Board, {config as boardConfig} from '@ciscospark/internal-plugin-board';
+
+describe(`plugin-board`, () => {
+  let spark;
+  const encryptedData = `encryptedData`;
+  const decryptedText = `decryptedText`;
+  const fakeURL = `https://encryption-a.wbx2.com/encryption/api/v1/keys/8a7d3d78-ce75-48aa-a943-2e8acf63fbc9`;
+
+  before(() => {
+    spark = new MockSpark({
+      children: {
+        board: Board
+      }
+    });
+
+    Object.assign(spark.internal, {
+      device: {
+        deviceType: `FAKE_DEVICE`
+      },
+      encryption: {
+        decryptText: sinon.stub().returns(Promise.resolve(decryptedText)),
+        encryptText: sinon.stub().returns(Promise.resolve(encryptedData)),
+        encryptBinary: sinon.stub().returns(Promise.resolve({
+          scr: {},
+          cdata: encryptedData
+        })),
+        decryptScr: sinon.stub().returns(Promise.resolve(`decryptedFoo`)),
+        encryptScr: sinon.stub().returns(Promise.resolve(`encryptedFoo`))
+      }
+    });
+
+    spark.config.board = boardConfig.board;
+  });
+
+  describe(`encryption`, () => {
+
+    describe(`#decryptContents`, () => {
+
+      before(() => {
+        sinon.stub(spark.internal.board, `decryptSingleContent`, sinon.stub().returns(Promise.resolve({})));
+        sinon.spy(spark.internal.board, `decryptSingleFileContent`);
+      });
+
+      after(() => {
+        spark.internal.board.decryptSingleContent.restore();
+        spark.internal.board.decryptSingleFileContent.restore();
+      });
+
+      afterEach(() => {
+        spark.internal.board.decryptSingleContent.reset();
+        spark.internal.board.decryptSingleFileContent.reset();
+        spark.internal.encryption.decryptScr.reset();
+        spark.internal.encryption.decryptText.reset();
+      });
+
+      it(`calls decryptSingleContent when type is not image`, () => {
+
+        const curveContents = {
+          items: [{
+            type: `STRING`,
+            payload: encryptedData,
+            encryptionKeyUrl: fakeURL
+          }]
+        };
+
+        return spark.internal.board.decryptContents(curveContents)
+          .then(() => {
+            assert.calledWith(spark.internal.board.decryptSingleContent, fakeURL, encryptedData);
+            assert.notCalled(spark.internal.encryption.decryptScr);
+            assert.notCalled(spark.internal.encryption.decryptText);
+          });
+      });
+
+      it(`calls decryptSingleFileContent when type is FILE`, () => {
+        const imageContents = {
+          items: [{
+            type: `FILE`,
+            payload: JSON.stringify({
+              type: `image`,
+              displayName: `encryptedDisplayName`
+            }),
+            file: {
+              scr: `encryptedScr`
+            },
+            encryptionKeyUrl: fakeURL
+          }]
+        };
+
+        return spark.internal.board.decryptContents(imageContents)
+          .then(() => {
+            assert.calledOnce(spark.internal.board.decryptSingleFileContent);
+            assert.calledWith(spark.internal.encryption.decryptText, fakeURL, JSON.stringify({type: `image`, displayName: `encryptedDisplayName`}));
+            assert.calledWith(spark.internal.encryption.decryptScr, fakeURL, `encryptedScr`);
+          });
+      });
+
+      it(`does not require payload when type is FILE`, () => {
+        const imageContents = {
+          items: [{
+            type: `FILE`,
+            file: {
+              scr: `encryptedScr`
+            },
+            encryptionKeyUrl: fakeURL
+          }]
+        };
+
+        return spark.internal.board.decryptContents(imageContents)
+          .then(() => {
+            assert.calledOnce(spark.internal.board.decryptSingleFileContent);
+            assert.notCalled(spark.internal.encryption.decryptText);
+            assert.calledWith(spark.internal.encryption.decryptScr, fakeURL, `encryptedScr`);
+          });
+      });
+
+      it(`decrypts FILE metadata displayName`, () => {
+        const imageContentsWithMetadata = {
+          items: [{
+            type: `FILE`,
+            payload: JSON.stringify({
+              type: `image`,
+              displayName: `encryptedDisplayName`
+            }),
+            file: {
+              scr: `encryptedScr`
+            },
+            encryptionKeyUrl: fakeURL
+          }]
+        };
+        spark.internal.encryption.decryptText.onFirstCall().returns(JSON.stringify({displayName: `decryptedDisplayName`}));
+        return spark.internal.board.decryptContents(imageContentsWithMetadata)
+          .then((contents) => {
+            assert.calledOnce(spark.internal.board.decryptSingleFileContent);
+            assert.calledWith(spark.internal.encryption.decryptScr, fakeURL, `encryptedScr`);
+            assert.calledWith(spark.internal.encryption.decryptText, fakeURL, JSON.stringify({type: `image`, displayName: `encryptedDisplayName`}));
+            assert.equal(contents[0].metadata.displayName, `decryptedDisplayName`);
+          });
+      });
+
+      it(`assigns FILE payload metadata to decrypted file`, () => {
+        const imageContentsWithMetadata = {
+          items: [{
+            type: `FILE`,
+            payload: JSON.stringify({
+              type: `image`,
+              size: 123
+            }),
+            file: {
+              scr: `encryptedScr`
+            },
+            encryptionKeyUrl: fakeURL
+          }]
+        };
+        spark.internal.encryption.decryptText.onFirstCall().returns(JSON.stringify({type: `image`, size: 123}));
+        return spark.internal.board.decryptContents(imageContentsWithMetadata)
+          .then((contents) => {
+            assert.calledOnce(spark.internal.board.decryptSingleFileContent);
+            assert.deepEqual(contents[0].metadata, {
+              type: `image`,
+              size: 123
+            });
+          });
+      });
+    });
+
+    describe(`#encryptContents`, () => {
+
+      before(() => {
+        sinon.stub(spark.internal.board, `encryptSingleContent`).returns(Promise.resolve({
+          encryptedData,
+          encryptionKeyUrl: fakeURL
+        }));
+      });
+
+      afterEach(() => {
+        spark.internal.board.encryptSingleContent.reset();
+      });
+
+      it(`calls encryptSingleContent when type is not image`, () => {
+
+        const curveContents = [{
+          type: `curve`
+        }];
+
+        return spark.internal.board.encryptContents(fakeURL, curveContents)
+          .then(() => {
+            assert.calledWith(spark.internal.board.encryptSingleContent, fakeURL, curveContents[0]);
+            assert.notCalled(spark.internal.encryption.encryptScr);
+          });
+      });
+
+      it(`calls encryptText and encryptScr when scr is found in content`, () => {
+
+        const imageContents = [{
+          displayName: `FileName`,
+          file: {
+            scr: {
+              loc: fakeURL
+            }
+          }
+        }];
+
+        return spark.internal.board.encryptContents(fakeURL, imageContents)
+          .then(() => {
+            assert.calledWith(spark.internal.encryption.encryptScr, fakeURL, {loc: fakeURL});
+            assert.calledWith(spark.internal.encryption.encryptText, fakeURL, JSON.stringify({displayName: `FileName`}));
+          });
+      });
+
+      it(`sets the device to config deviceType`, () => {
+        const curveContents = [{
+          type: `curve`
+        }];
+
+        return spark.internal.board.encryptContents(fakeURL, curveContents)
+          .then((res) => {
+            assert.equal(res[0].device, `FAKE_DEVICE`);
+          });
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
- add lockChannelForDeletion to lock channel before deleting or to tell
  whether a channel cannot be locked since it is in use
- move encryption related unit tests to unit/spec/encryption