### PR TITLE
feat(@ciscospark/spark-core): add error support for empty params

### DIFF
--- a/packages/node_modules/@ciscospark/spark-core/src/lib/batcher.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/lib/batcher.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
+import {has} from 'lodash';
 import SparkPlugin from './spark-plugin';
 import {
   cappedDebounce,
@@ -167,11 +168,16 @@ const Batcher = SparkPlugin.extend({
    * @returns {Promise<undefined>}
    */
   handleHttpError(reason) {
-    const msg = reason.message || reason.body || reason;
-    return Promise.all(reason.options.body.map((item) => this.getDeferredForRequest(item)
-      .then((defer) => {
-        defer.reject(msg);
-      })));
+    if (reason instanceof SparkHttpError) {
+      if (has(reason, `options.body.map`)) {
+        return Promise.all(reason.options.body.map((item) => this.getDeferredForRequest(item)
+          .then((defer) => {
+            defer.reject(reason);
+          })));
+      }
+    }
+    this.logger.error(`http error handler called without a SparkHttpError object`, reason);
+    return Promise.reject(reason);
   },
 
   /**

--- a/packages/node_modules/@ciscospark/spark-core/test/unit/spec/lib/batcher.js
+++ b/packages/node_modules/@ciscospark/spark-core/test/unit/spec/lib/batcher.js
@@ -295,5 +295,11 @@ describe(`spark-core`, () => {
         });
       });
     });
+
+    describe(`#handleHttpError()`, () => {
+      it(`handles a non SparkHttpError object passed`, () => {
+        return assert.isRejected(spark.internal.batcher.handleHttpError(`simulated failure`), /simulated failure/);
+      });
+    });
   });
 });


### PR DESCRIPTION
Batcher #handleHttpError could receive an object or string that isn't a SparkHttpError

Hopefully this resolves https://voxeolabs.atlassian.net/browse/SSDK-1475