### PR TITLE
feat(@ciscospark/i-p-wdm): support Spark High Availability Design

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
@@ -113,10 +113,16 @@ const Mercury = SparkPlugin.extend({
 
   _prepareUrl(webSocketUrl) {
     if (!webSocketUrl) {
-      webSocketUrl = this.spark.internal.device.currentWebSocketUrl;
+      webSocketUrl = this.spark.internal.device.webSocketUrl;
     }
 
-    return this.spark.internal.feature.getFeature(`developer`, `web-shared-mercury`)
+    return this.spark.internal.feature.getFeature(`developer`, `web-ha-messaging`)
+      .then((haMessagingEnabled) => {
+        if (haMessagingEnabled) {
+          webSocketUrl = this.spark.internal.device.currentWebSocketUrl;
+        }
+      })
+      .then(() => this.spark.internal.feature.getFeature(`developer`, `web-shared-mercury`))
       .then((webSharedMercury) => {
         webSocketUrl = url.parse(webSocketUrl, true);
         Object.assign(webSocketUrl.query, {
@@ -196,8 +202,14 @@ const Mercury = SparkPlugin.extend({
           return callback(reason);
         }
         else if (reason instanceof ConnectionError) {
-          this.logger.info(`mercury: received a generic connection error, will try to connect to another datacenter`);
-          return this.spark.internal.device.markUrlFailedAndGetNew(`mercuryConnection`)
+          return this.spark.internal.feature.getFeature(`developer`, `web-ha-messaging`)
+            .then((haMessagingEnabled) => {
+              if (haMessagingEnabled) {
+                this.logger.info(`mercury: received a generic connection error, will try to connect to another datacenter`);
+                return this.spark.internal.device.markUrlFailedAndGetNew(`mercuryConnection`);
+              }
+              return null;
+            })
             .then(() => callback(reason));
         }
 

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
@@ -119,8 +119,12 @@ const Mercury = SparkPlugin.extend({
     return this.spark.internal.feature.getFeature(`developer`, `web-ha-messaging`)
       .then((haMessagingEnabled) => {
         if (haMessagingEnabled) {
-          webSocketUrl = this.spark.internal.device.currentWebSocketUrl;
+          return this.spark.internal.device.getWebSocketUrl();
         }
+        return webSocketUrl;
+      })
+      .then((wsUrl) => {
+        webSocketUrl = wsUrl;
       })
       .then(() => this.spark.internal.feature.getFeature(`developer`, `web-shared-mercury`))
       .then((webSharedMercury) => {
@@ -149,19 +153,23 @@ const Mercury = SparkPlugin.extend({
 
   _attemptConnection(callback) {
     const socket = new Socket();
+    let attemptWSUrl;
     socket.on(`close`, (...args) => this._onclose(...args));
     socket.on(`message`, (...args) => this._onmessage(...args));
     socket.on(`sequence-mismatch`, (...args) => this._emit(`sequence-mismatch`, ...args));
 
     Promise.all([this._prepareUrl(), this.spark.credentials.getUserToken()])
-      .then(([webSocketUrl, token]) => socket.open(webSocketUrl, {
-        forceCloseDelay: this.config.forceCloseDelay,
-        pingInterval: this.config.pingInterval,
-        pongTimeout: this.config.pongTimeout,
-        token: token.toString(),
-        trackingId: `${this.spark.sessionId}_${Date.now()}`,
-        logger: this.logger
-      }))
+      .then(([webSocketUrl, token]) => {
+        attemptWSUrl = webSocketUrl;
+        return socket.open(webSocketUrl, {
+          forceCloseDelay: this.config.forceCloseDelay,
+          pingInterval: this.config.pingInterval,
+          pongTimeout: this.config.pongTimeout,
+          token: token.toString(),
+          trackingId: `${this.spark.sessionId}_${Date.now()}`,
+          logger: this.logger
+        });
+      })
       .then(() => {
         this.socket = socket;
         callback();
@@ -206,7 +214,7 @@ const Mercury = SparkPlugin.extend({
             .then((haMessagingEnabled) => {
               if (haMessagingEnabled) {
                 this.logger.info(`mercury: received a generic connection error, will try to connect to another datacenter`);
-                return this.spark.internal.device.markUrlFailedAndGetNew(`mercuryConnection`);
+                return this.spark.internal.device.markUrlFailedAndGetNew(attemptWSUrl);
               }
               return null;
             })

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
@@ -12,7 +12,8 @@ import {
   BadRequest,
   Forbidden,
   NotAuthorized,
-  UnknownResponse
+  UnknownResponse,
+  ConnectionError
   // NotFound
 } from './errors';
 import url from 'url';
@@ -112,8 +113,9 @@ const Mercury = SparkPlugin.extend({
 
   _prepareUrl(webSocketUrl) {
     if (!webSocketUrl) {
-      webSocketUrl = this.spark.internal.device.webSocketUrl;
+      webSocketUrl = this.spark.internal.device.currentWebSocketUrl;
     }
+
     return this.spark.internal.feature.getFeature(`developer`, `web-shared-mercury`)
       .then((webSharedMercury) => {
         webSocketUrl = url.parse(webSocketUrl, true);
@@ -193,6 +195,12 @@ const Mercury = SparkPlugin.extend({
           this.backoffCall.abort();
           return callback(reason);
         }
+        else if (reason instanceof ConnectionError) {
+          this.logger.info(`mercury: received a generic connection error, will try to connect to another datacenter`);
+          return this.spark.internal.device.markUrlFailedAndGetNew(`mercuryConnection`)
+            .then(() => callback(reason));
+        }
+
         return callback(reason);
       })
       .catch((reason) => {

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/integration/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/integration/spec/mercury.js
@@ -67,7 +67,7 @@ describe(`plugin-mercury`, function() {
         it(`connects to mercury`, () => assert.isFulfilled(spark.internal.mercury.connect()));
       });
 
-      describe(`when web-ha-messasing is enabled`, () => {
+      describe(`when web-ha-messaging is enabled`, () => {
         it(`connects to mercury using service catalog url`, () => {
           let defaultWebSocketUrl;
           return spark.internal.device.register()

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/integration/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/integration/spec/mercury.js
@@ -66,6 +66,23 @@ describe(`plugin-mercury`, function() {
 
         it(`connects to mercury`, () => assert.isFulfilled(spark.internal.mercury.connect()));
       });
+
+      describe(`when web-ha-messasing is enabled`, () => {
+        it(`connects to mercury using service catalog url`, () => {
+          let defaultWebSocketUrl;
+          return spark.internal.device.register()
+            .then(() => {
+              defaultWebSocketUrl = spark.internal.device.webSocketUrl;
+            })
+            .then(() => spark.internal.feature.setFeature(`developer`, `web-ha-messaging`, true))
+            .then(() => assert.isFulfilled(spark.internal.mercury.connect()))
+            .then(() => spark.internal.device.getWebSocketUrl())
+            .then((wsUrl) => {
+              assert.notEqual(defaultWebSocketUrl, spark.internal.mercury.socket.url);
+              assert.include(spark.internal.mercury.socket.url, wsUrl);
+            });
+        });
+      });
     });
 
     it(`emits messages that arrive before authorization completes`, () => {

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -282,7 +282,7 @@ describe(`plugin-mercury`, () => {
         //   });
         // });
 
-        describe(`when web-ha-messasing feature is enabled`, () => {
+        describe(`when web-ha-messaging feature is enabled`, () => {
           it(`marks current socket url as failed and get new one on Connection Error`, () => {
             spark.internal.feature.getFeature.returns(Promise.resolve(true));
             socketOpenStub.restore();
@@ -476,7 +476,7 @@ describe(`plugin-mercury`, () => {
           assert.notMatch(wsUrl, /multipleConnections/);
         }));
 
-      describe(`when web-ha-messasing is enabled`, () => {
+      describe(`when web-ha-messaging is enabled`, () => {
         it(`uses webSocketUrl provided by device`, () => {
           spark.internal.device.getWebSocketUrl = sinon.stub().returns(Promise.resolve(`ws://example-2.com`));
           spark.internal.feature.getFeature.onCall(0).returns(Promise.resolve(true));

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -66,7 +66,7 @@ describe(`plugin-mercury`, () => {
         refresh: sinon.stub().returns(Promise.resolve()),
         markUrlFailedAndGetNew: sinon.stub().returns(Promise.resolve()),
         webSocketUrl: `ws://example.com`,
-        currentWebSocketUrl: `ws://example-2.com`
+        getWebSocketUrl: sinon.stub().returns(Promise.resolve(`ws://example-2.com`))
       };
 
       spark.trackingId = `fakeTrackingId`;
@@ -477,9 +477,9 @@ describe(`plugin-mercury`, () => {
         }));
 
       describe(`when web-ha-messasing is enabled`, () => {
-        it(`uses the currentWebSocketUrl`, () => {
+        it(`uses webSocketUrl provided by device`, () => {
+          spark.internal.device.getWebSocketUrl = sinon.stub().returns(Promise.resolve(`ws://example-2.com`));
           spark.internal.feature.getFeature.onCall(0).returns(Promise.resolve(true));
-          spark.internal.device.currentWebSocketUrl = `ws://example-2.com`;
           return assert.isFulfilled(spark.internal.mercury._prepareUrl())
             .then((wsUrl) => assert.match(wsUrl, /example-2.com/));
         });

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -64,7 +64,8 @@ describe(`plugin-mercury`, () => {
       spark.internal.device = {
         register: sinon.stub().returns(Promise.resolve()),
         refresh: sinon.stub().returns(Promise.resolve()),
-        webSocketUrl: `ws://example.com`
+        markUrlFailedAndGetNew: sinon.stub().returns(Promise.resolve()),
+        currentWebSocketUrl: `ws://example.com`
       };
 
       spark.trackingId = `fakeTrackingId`;
@@ -223,6 +224,20 @@ describe(`plugin-mercury`, () => {
             })
             .then(() => {
               assert.calledThrice(Socket.prototype.open);
+            });
+        });
+
+        it(`marks current socket url as failed and get new one`, () => {
+          socketOpenStub.restore();
+          socketOpenStub = sinon.stub(Socket.prototype, `open`).returns(Promise.resolve());
+          socketOpenStub.onCall(0).returns(Promise.reject(new ConnectionError({code: 4001})));
+          const promise = mercury.connect();
+          return promiseTick(7)
+            .then(() => {
+              assert.calledOnce(spark.internal.device.markUrlFailedAndGetNew);
+              assert.notCalled(spark.internal.device.refresh);
+              clock.tick(1000);
+              return assert.isFulfilled(promise);
             });
         });
 
@@ -435,7 +450,7 @@ describe(`plugin-mercury`, () => {
 
     describe(`#_prepareUrl()`, () => {
       beforeEach(() => {
-        spark.internal.device.webSocketUrl = `ws://example.com`;
+        spark.internal.device.currentWebSocketUrl = `ws://example.com`;
       });
 
       it(`requests text-mode WebSockets`, () => assert.isFulfilled(spark.internal.mercury._prepareUrl())

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -65,7 +65,8 @@ describe(`plugin-mercury`, () => {
         register: sinon.stub().returns(Promise.resolve()),
         refresh: sinon.stub().returns(Promise.resolve()),
         markUrlFailedAndGetNew: sinon.stub().returns(Promise.resolve()),
-        currentWebSocketUrl: `ws://example.com`
+        webSocketUrl: `ws://example.com`,
+        currentWebSocketUrl: `ws://example-2.com`
       };
 
       spark.trackingId = `fakeTrackingId`;
@@ -146,23 +147,23 @@ describe(`plugin-mercury`, () => {
           assert.notCalled(Socket.prototype.open);
 
           const promise = mercury.connect();
-          return promiseTick(4)
+          return promiseTick(5)
             .then(() => {
               assert.calledOnce(Socket.prototype.open);
-              return promiseTick(4);
+              return promiseTick(5);
             })
             .then(() => {
               clock.tick(mercury.config.backoffTimeReset);
-              return promiseTick(4);
+              return promiseTick(5);
             })
             .then(() => {
               assert.calledTwice(Socket.prototype.open);
               clock.tick(2 * mercury.config.backoffTimeReset);
-              return promiseTick(4);
+              return promiseTick(5);
             })
             .then(() => {
               assert.calledThrice(Socket.prototype.open);
-              clock.tick(4 * mercury.config.backoffTimeReset);
+              clock.tick(5 * mercury.config.backoffTimeReset);
               return assert.isRejected(promise);
             })
             .then(() => {
@@ -196,48 +197,34 @@ describe(`plugin-mercury`, () => {
           assert.notCalled(Socket.prototype.open);
 
           const promise = mercury.connect();
-          return promiseTick(4)
+          return promiseTick(5)
             .then(() => {
               assert.calledOnce(Socket.prototype.open);
               // I'm not sure why, but it's important the clock doesn't advance
               // until a tick happens
-              return promiseTick(4);
+              return promiseTick(5);
             })
             .then(() => {
               clock.tick(mercury.config.backoffTimeReset);
-              return promiseTick(4);
+              return promiseTick(5);
             })
             .then(() => {
               assert.calledTwice(Socket.prototype.open);
               clock.tick(2 * mercury.config.backoffTimeReset);
-              return promiseTick(4);
+              return promiseTick(5);
             })
             .then(() => {
               assert.calledThrice(Socket.prototype.open);
-              clock.tick(4 * mercury.config.backoffTimeReset);
+              clock.tick(5 * mercury.config.backoffTimeReset);
               return assert.isFulfilled(promise);
             })
             .then(() => {
               assert.calledThrice(Socket.prototype.open);
               clock.tick(8 * mercury.config.backoffTimeReset);
-              return promiseTick(4);
+              return promiseTick(5);
             })
             .then(() => {
               assert.calledThrice(Socket.prototype.open);
-            });
-        });
-
-        it(`marks current socket url as failed and get new one`, () => {
-          socketOpenStub.restore();
-          socketOpenStub = sinon.stub(Socket.prototype, `open`).returns(Promise.resolve());
-          socketOpenStub.onCall(0).returns(Promise.reject(new ConnectionError({code: 4001})));
-          const promise = mercury.connect();
-          return promiseTick(7)
-            .then(() => {
-              assert.calledOnce(spark.internal.device.markUrlFailedAndGetNew);
-              assert.notCalled(spark.internal.device.refresh);
-              clock.tick(1000);
-              return assert.isFulfilled(promise);
             });
         });
 
@@ -294,6 +281,24 @@ describe(`plugin-mercury`, () => {
         //       });
         //   });
         // });
+
+        describe(`when web-ha-messasing feature is enabled`, () => {
+          it(`marks current socket url as failed and get new one on Connection Error`, () => {
+            spark.internal.feature.getFeature.returns(Promise.resolve(true));
+            socketOpenStub.restore();
+            socketOpenStub = sinon.stub(Socket.prototype, `open`).returns(Promise.resolve());
+            socketOpenStub.onCall(0).returns(Promise.reject(new ConnectionError({code: 4001})));
+            const promise = mercury.connect();
+            return promiseTick(7)
+              .then(() => {
+                assert.calledOnce(spark.internal.device.markUrlFailedAndGetNew);
+                assert.notCalled(spark.internal.device.refresh);
+                clock.tick(1000);
+                return assert.isFulfilled(promise);
+              });
+          });
+        });
+
       });
 
       describe(`when connected`, () => {
@@ -450,8 +455,11 @@ describe(`plugin-mercury`, () => {
 
     describe(`#_prepareUrl()`, () => {
       beforeEach(() => {
-        spark.internal.device.currentWebSocketUrl = `ws://example.com`;
+        spark.internal.device.webSocketUrl = `ws://example.com`;
       });
+
+      it(`uses device default webSocketUrl`, () => assert.isFulfilled(spark.internal.mercury._prepareUrl())
+        .then((wsUrl) => assert.match(wsUrl, /example.com/)));
 
       it(`requests text-mode WebSockets`, () => assert.isFulfilled(spark.internal.mercury._prepareUrl())
         .then((wsUrl) => assert.match(wsUrl, /outboundWireFormat=text/)));
@@ -467,6 +475,15 @@ describe(`plugin-mercury`, () => {
           assert.notMatch(wsUrl, /isRegistrationRefreshEnabled/);
           assert.notMatch(wsUrl, /multipleConnections/);
         }));
+
+      describe(`when web-ha-messasing is enabled`, () => {
+        it(`uses the currentWebSocketUrl`, () => {
+          spark.internal.feature.getFeature.onCall(0).returns(Promise.resolve(true));
+          spark.internal.device.currentWebSocketUrl = `ws://example-2.com`;
+          return assert.isFulfilled(spark.internal.mercury._prepareUrl())
+            .then((wsUrl) => assert.match(wsUrl, /example-2.com/));
+        });
+      });
 
       describe(`when 'web-shared-socket' is enabled`, () => {
         beforeEach(() => {

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import {oneFlight, tap} from '@ciscospark/common';
+import {oneFlight} from '@ciscospark/common';
 import {safeSetTimeout} from '@ciscospark/common-timers';
 import {omit} from 'lodash';
 import util from 'util';
@@ -79,15 +79,6 @@ const Device = SparkPlugin.extend({
       fn() {
         return Boolean(this.url);
       }
-    },
-    currentWebSocketUrl: {
-      deps: [`webSocketUrl`, `serviceHostMap`, `serviceCatalog`],
-      fn() {
-        if (this.webSocketUrl) {
-          return this._useUrlFromServiceCatalog(this.webSocketUrl, `mercuryConnection`);
-        }
-        return null;
-      }
     }
   },
 
@@ -123,34 +114,35 @@ const Device = SparkPlugin.extend({
     return Promise.resolve(this._getServiceUrl(this.config.preDiscoveryServices, service));
   },
 
-  markUrlFailedAndGetNew(service) {
-    if (!service) {
-      return Promise.reject(new Error(`\`service\` is a required parameter`));
+  getWebSocketUrl() {
+    return this.useServiceCatalogUrl(this.webSocketUrl);
+  },
+
+  useServiceCatalogUrl(uri) {
+    return this.serviceCatalog.inferServiceFromUrl(uri)
+      .then((s) => s.replaceUrlWithCurrentHost(uri));
+  },
+
+  markUrlFailedAndGetNew(url) {
+    if (!url) {
+      return Promise.reject(new Error(`\`url\` is a required parameter`));
     }
 
-    const s = this.serviceCatalog.get(`${service}ServiceUrl`);
-    if (s) {
-      s.markHostFailed();
-      s.cycleHost();
-      const host = s.getCurrentHost();
-      if (host.failed) {
-        this.logger.info(`device: all known hosts have failed, refreshing for new ones`);
-        // we've cycled though all hosts, now we rely on wdm service to return
-        // new available datacenters
-        return new Promise((resolve) => {
-          this.refresh();
-          this.on(`serviceCatalogUpdated`, () => {
-            resolve(s.url);
-          });
-        });
-      }
+    return this.serviceCatalog.markFailedAndCycleUrl(url)
+      .then((uri) => uri)
+      // it's likely we fail here because we've cycled though all hosts,
+      // now we rely on wdm service to return new available datacenters
+      .catch(() => this._fetchNewUrls(url));
+  },
 
-      return Promise.resolve(s.url)
-        // this will cause currentWebSocketUrl to use the new host
-        .then(tap(() => this.trigger(`change:serviceCatalog`)));
-    }
-
-    return Promise.reject(new Error(`service ${service} not found`));
+  _fetchNewUrls(url) {
+    // we want to get the current service first, just in case the
+    // refreshed catalog has different host names
+    return new Promise((resolve) => this.serviceCatalog.inferServiceFromUrl(url)
+      .then((s) => {
+        this.refresh();
+        this.on(`serviceCatalogUpdated`, () => resolve(s.url));
+      }));
   },
 
   @persist(`@`, decider)
@@ -336,14 +328,6 @@ const Device = SparkPlugin.extend({
     Reflect.apply(SparkPlugin.prototype.clear, this, args);
   },
 
-  _useUrlFromServiceCatalog(uri, service) {
-    const s = this.serviceCatalog.get(`${service}ServiceUrl`);
-    if (!s) {
-      return uri;
-    }
-    return s.replaceUrlWithCurrentHost(uri);
-  },
-
   _processRegistrationSuccess(res) {
     this.logger.info(`device: received registration payload`);
     this.set(res.body);
@@ -359,18 +343,11 @@ const Device = SparkPlugin.extend({
       const uri = newRegistration.services[service];
       const u = Url.parse(uri);
       const hosts = newRegistration.serviceHostMap.hostCatalog[u.host];
-      const existingService = this.serviceCatalog.get(service);
-      if (existingService) {
-        existingService.defaultUrl = uri;
-        existingService.availableHosts = hosts || [];
-      }
-      else {
-        this.serviceCatalog.add({
-          service,
-          defaultUrl: uri,
-          availableHosts: hosts || []
-        });
-      }
+      this.serviceCatalog.set({
+        service,
+        defaultUrl: uri,
+        availableHosts: hosts || []
+      }, {remove: false});
     });
     this.trigger(`serviceCatalogUpdated`);
   },

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -226,9 +226,12 @@ const Device = SparkPlugin.extend({
       return Promise.reject(new Error(`\`service\` is a required parameter`));
     }
 
-    const s = this.serviceCatalog.get(`${service}ServiceUrl`);
-    if (s) {
-      return Promise.resolve(s.url);
+    const feature = this.features[`developer`].get(`web-ha-messasing`);
+    if (feature && feature.value) {
+      const s = this.serviceCatalog.get(`${service}ServiceUrl`);
+      if (s) {
+        return Promise.resolve(s.url);
+      }
     }
 
     return Promise.resolve(target[`${service}ServiceUrl`]);

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -2,12 +2,14 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import {oneFlight} from '@ciscospark/common';
+import {oneFlight, tap} from '@ciscospark/common';
 import {safeSetTimeout} from '@ciscospark/common-timers';
 import {omit} from 'lodash';
 import util from 'util';
 import FeaturesModel from './features-model';
+import ServiceCollection from './service-collection';
 import {persist, waitForValue, SparkPlugin} from '@ciscospark/spark-core';
+import * as Url from 'url';
 
 /**
  * Decides if this device should be persisted to boundedStorage, based on
@@ -21,6 +23,10 @@ function decider() {
 const Device = SparkPlugin.extend({
   children: {
     features: FeaturesModel
+  },
+
+  collections: {
+    serviceCatalog: ServiceCollection
   },
 
   idAttribute: `url`,
@@ -40,6 +46,15 @@ const Device = SparkPlugin.extend({
       // initialize `object` properties, the docs lie.
       default() {
         return {};
+      },
+      type: `object`
+    },
+    serviceHostMap: {
+      default() {
+        return {
+          serviceLinks: {},
+          hostCatalog: {}
+        };
       },
       type: `object`
     },
@@ -63,6 +78,15 @@ const Device = SparkPlugin.extend({
       deps: [`url`],
       fn() {
         return Boolean(this.url);
+      }
+    },
+    currentWebSocketUrl: {
+      deps: [`webSocketUrl`, `serviceHostMap`, `serviceCatalog`],
+      fn() {
+        if (this.webSocketUrl) {
+          return this._useUrlFromServiceCatalog(this.webSocketUrl, `mercuryConnection`);
+        }
+        return null;
       }
     }
   },
@@ -99,6 +123,36 @@ const Device = SparkPlugin.extend({
     return Promise.resolve(this._getServiceUrl(this.config.preDiscoveryServices, service));
   },
 
+  markUrlFailedAndGetNew(service) {
+    if (!service) {
+      return Promise.reject(new Error(`\`service\` is a required parameter`));
+    }
+
+    const s = this.serviceCatalog.get(`${service}ServiceUrl`);
+    if (s) {
+      s.markHostFailed();
+      s.cycleHost();
+      const host = s.getCurrentHost();
+      if (host.failed) {
+        this.logger.info(`device: all known hosts have failed, refreshing for new ones`);
+        // we've cycled though all hosts, now we rely on wdm service to return
+        // new available datacenters
+        return new Promise((resolve) => {
+          this.refresh();
+          this.on(`serviceCatalogUpdated`, () => {
+            resolve(s.url);
+          });
+        });
+      }
+
+      return Promise.resolve(s.url)
+        // this will cause currentWebSocketUrl to use the new host
+        .then(tap(() => this.trigger(`change:serviceCatalog`)));
+    }
+
+    return Promise.reject(new Error(`service ${service} not found`));
+  },
+
   @persist(`@`, decider)
   initialize(...args) {
     Reflect.apply(SparkPlugin.prototype.initialize, this, args);
@@ -110,6 +164,8 @@ const Device = SparkPlugin.extend({
         this.trigger(`change:features`, this, this.features, options);
       });
     });
+
+    this.on(`change:serviceHostMap`, this._updateServiceCatalog);
 
     this.listenToAndRun(this, `change:intranetInactivityCheckUrl`, () => this._resetLogoutTimer());
     this.listenToAndRun(this, `change:intranetInactivityDuration`, () => this._resetLogoutTimer());
@@ -168,6 +224,11 @@ const Device = SparkPlugin.extend({
 
     if (!service) {
       return Promise.reject(new Error(`\`service\` is a required parameter`));
+    }
+
+    const s = this.serviceCatalog.get(`${service}ServiceUrl`);
+    if (s) {
+      return Promise.resolve(s.url);
     }
 
     return Promise.resolve(target[`${service}ServiceUrl`]);
@@ -272,6 +333,14 @@ const Device = SparkPlugin.extend({
     Reflect.apply(SparkPlugin.prototype.clear, this, args);
   },
 
+  _useUrlFromServiceCatalog(uri, service) {
+    const s = this.serviceCatalog.get(`${service}ServiceUrl`);
+    if (!s) {
+      return uri;
+    }
+    return s.replaceUrlWithCurrentHost(uri);
+  },
+
   _processRegistrationSuccess(res) {
     this.logger.info(`device: received registration payload`);
     this.set(res.body);
@@ -280,6 +349,27 @@ const Device = SparkPlugin.extend({
       const delay = (this.config.ephemeralDeviceTTL / 2 + 60) * 1000;
       this.refreshTimer = safeSetTimeout(() => this.refresh(), delay);
     }
+  },
+
+  _updateServiceCatalog(newRegistration) {
+    Object.keys(newRegistration.services).forEach((service) => {
+      const uri = newRegistration.services[service];
+      const u = Url.parse(uri);
+      const hosts = newRegistration.serviceHostMap.hostCatalog[u.host];
+      const existingService = this.serviceCatalog.get(service);
+      if (existingService) {
+        existingService.defaultUrl = uri;
+        existingService.availableHosts = hosts || [];
+      }
+      else {
+        this.serviceCatalog.add({
+          service,
+          defaultUrl: uri,
+          availableHosts: hosts || []
+        });
+      }
+    });
+    this.trigger(`serviceCatalogUpdated`);
   },
 
   _resetLogoutTimer() {

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -9,7 +9,7 @@ import util from 'util';
 import FeaturesModel from './features-model';
 import ServiceCollection from './service-collection';
 import {persist, waitForValue, SparkPlugin} from '@ciscospark/spark-core';
-import * as Url from 'url';
+import Url from 'url';
 
 /**
  * Decides if this device should be persisted to boundedStorage, based on
@@ -218,7 +218,7 @@ const Device = SparkPlugin.extend({
       return Promise.reject(new Error(`\`service\` is a required parameter`));
     }
 
-    const feature = this.features[`developer`].get(`web-ha-messasing`);
+    const feature = this.features[`developer`].get(`web-ha-messaging`);
     if (feature && feature.value) {
       const s = this.serviceCatalog.get(`${service}ServiceUrl`);
       if (s) {

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
@@ -1,0 +1,13 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import AmpCollection from 'ampersand-collection';
+import ServiceModel from './service-model';
+
+const ServiceCollection = AmpCollection.extend({
+  mainIndex: `service`,
+  model: ServiceModel
+});
+
+export default ServiceCollection;

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
@@ -7,7 +7,34 @@ import ServiceModel from './service-model';
 
 const ServiceCollection = AmpCollection.extend({
   mainIndex: `service`,
-  model: ServiceModel
+  model: ServiceModel,
+
+  markFailedAndCycleUrl(uri) {
+    if (!uri) {
+      return Promise.reject(new Error(`\`uri\` is a required parameter`));
+    }
+
+    return this.inferServiceFromUrl(uri)
+      .then((service) => {
+        service.markHostFailed(uri);
+        return service.cycleNextHost()
+          .then(() => service.url);
+      });
+  },
+
+  inferServiceFromUrl(uri) {
+    const services = this.filter((service) => service.doesUrlBelongToService(uri));
+    if (services.length >= 1) {
+      return Promise.resolve(services[0]);
+    }
+
+    return Promise.reject(new Error(`Unable to infer service for this url ${uri}`));
+  },
+
+  inferServiceNameFromUrl(uri) {
+    return this.inferServiceFromUrl(uri)
+      .then((service) => service.service);
+  }
 });
 
 export default ServiceCollection;

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
@@ -5,10 +5,20 @@
 import AmpCollection from 'ampersand-collection';
 import ServiceModel from './service-model';
 
+/**
+ * Collection of catalog services parsed from wdm registration.services and
+ * registration.serviceHostMap.hostCatalog
+ * @class
+ */
 const ServiceCollection = AmpCollection.extend({
   mainIndex: `service`,
   model: ServiceModel,
 
+  /**
+   * Mark the current host as failed and grab another url for connection
+   * @param {string} uri Mark the host of this url as fail
+   * @returns {string} new Url for connection
+   */
   markFailedAndCycleUrl(uri) {
     if (!uri) {
       return Promise.reject(new Error(`\`uri\` is a required parameter`));
@@ -22,6 +32,11 @@ const ServiceCollection = AmpCollection.extend({
       });
   },
 
+  /**
+   * Find out what service this url belongs to (by looking at the host name)
+   * @param {string} uri
+   * @returns {Promise<ServiceModel>}
+   */
   inferServiceFromUrl(uri) {
     const services = this.filter((service) => service.doesUrlBelongToService(uri));
     if (services.length >= 1) {
@@ -31,6 +46,12 @@ const ServiceCollection = AmpCollection.extend({
     return Promise.reject(new Error(`Unable to infer service for this url ${uri}`));
   },
 
+  /**
+   * Find out what service this url belongs to, this returns the service name
+   * instead of the service object
+   * @param {string} uri Mark the host of this url as fail
+   * @returns {Promise<ServiceModel.Service>}
+   */
   inferServiceNameFromUrl(uri) {
     return this.inferServiceFromUrl(uri)
       .then((service) => service.service);

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
@@ -6,7 +6,25 @@ import AmpState from 'ampersand-state';
 import {defaults, isObject, some, find} from 'lodash';
 import url from 'url';
 
+/**
+ * Represent a service parsed from wdm registration.services and
+ * registration.serviceHostMap.hostCatalog
+ * @param {string} service Service name
+ * @param {string} defaultUrl Url provided in registration.services
+ * @param {Array<Host>} availableHosts Available datacenters from
+ * registration.serviceHostMap sorted by priority
+ * @param {string} url Basically is the defaultUrl replaced with host provided in
+ * the catalog
+ * @class
+ */
 const ServiceModel = AmpState.extend({
+  /**
+    * @typedef {Object} Host - Represent a datacenter
+    * @property {int} priority - Closer to 0 is higher priority.
+    * @property {string} host - Host name.
+    * @property {boolean} failed - True when cannot connect to url.
+    */
+
   props: {
     service: `string`,
     defaultUrl: `string`,
@@ -26,13 +44,6 @@ const ServiceModel = AmpState.extend({
   },
 
   derived: {
-    availableUrls: {
-      deps: [`defaultUrl`, `availableHosts`],
-      fn() {
-        const urls = this.availableHosts.map((host) => this._changeUrlHost(this.defaultUrl, host.host));
-        return urls;
-      }
-    },
     url: {
       deps: [`defaultUrl`, `availableHosts`, `currentHostIndex`],
       fn() {
@@ -60,12 +71,14 @@ const ServiceModel = AmpState.extend({
 
   idAttribute: `service`,
 
+  // Override AmpersandState.serialize so we can return the latest url
   serialize(...args) {
     const attrs = Reflect.apply(AmpState.prototype.serialize, this, args);
     attrs.url = this.url;
     return attrs;
   },
 
+  // Override parse
   parse(attrs) {
     if (!attrs) {
       return {};
@@ -101,6 +114,13 @@ const ServiceModel = AmpState.extend({
     return Reflect.apply(AmpState.prototype.set, this, [attrs, options]);
   },
 
+
+  /**
+   * Mark the current host as failing or if a uri is provided, find the host
+   * and mark it as fail
+   * @param {string} uri Mark the host of this url as fail
+   * @returns {undefined}
+   */
   markHostFailed(uri) {
     let host = this.getCurrentHost();
 
@@ -114,6 +134,11 @@ const ServiceModel = AmpState.extend({
     }
   },
 
+  /**
+   * Return the next available host, which is usually the next higher priority
+   * host that has not yet been marked as failed
+   * @returns {Promise<Host>}
+   */
   cycleNextHost() {
     for (let i = 0; i < this.availableHosts.length; i++) {
       const host = this.availableHosts[i];
@@ -127,6 +152,11 @@ const ServiceModel = AmpState.extend({
     return Promise.reject(new Error(`All hosts have failed for ${this.service}`));
   },
 
+  /**
+   * Check if a url comes from this service
+   * @param {string} uri
+   * @returns {Boolean}
+   */
   doesUrlBelongToService(uri) {
     const urlObj = url.parse(uri);
     const hosts = this.availableHosts.map((h) => h.host);
@@ -134,14 +164,28 @@ const ServiceModel = AmpState.extend({
     return some(hosts, (host) => host === urlObj.host);
   },
 
+  /**
+   * Return the url for this service based on the active host
+   * @returns {string}
+   */
   getCurrentUrl() {
     return this.url;
   },
 
+  /**
+   * Return the current host/datacenter
+   * @returns {Host}
+   */
   getCurrentHost() {
     return this.availableHosts[this.currentHostIndex];
   },
 
+
+  /**
+   * Replace provided url by the current active host
+   * @param {string} uri
+   * @returns {string} uri
+   */
   replaceUrlWithCurrentHost(uri) {
     return this._changeUrlHost(uri, this.getCurrentHost().host);
   },

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
@@ -3,7 +3,7 @@
  */
 
 import AmpState from 'ampersand-state';
-import {defaults, isObject} from 'lodash';
+import {defaults, isObject, some, find} from 'lodash';
 import url from 'url';
 
 const ServiceModel = AmpState.extend({
@@ -26,6 +26,13 @@ const ServiceModel = AmpState.extend({
   },
 
   derived: {
+    availableUrls: {
+      deps: [`defaultUrl`, `availableHosts`],
+      fn() {
+        const urls = this.availableHosts.map((host) => this._changeUrlHost(this.defaultUrl, host.host));
+        return urls;
+      }
+    },
     url: {
       deps: [`defaultUrl`, `availableHosts`, `currentHostIndex`],
       fn() {
@@ -94,24 +101,40 @@ const ServiceModel = AmpState.extend({
     return Reflect.apply(AmpState.prototype.set, this, [attrs, options]);
   },
 
-  markHostFailed() {
-    const currentHost = this.getCurrentHost();
-    currentHost.failed = true;
-  },
+  markHostFailed(uri) {
+    let host = this.getCurrentHost();
 
-  cycleHost() {
-    this.currentHostIndex += 1;
-    if (this.currentHostIndex >= this.availableHosts.length) {
-      this.currentHostIndex = 0;
+    if (uri) {
+      const urlObj = url.parse(uri);
+      host = find(this.availableHosts, (h) => h.host === urlObj.host);
+    }
+
+    if (host) {
+      host.failed = true;
     }
   },
 
-  getCurrentUrl() {
-    return this.url;
+  cycleNextHost() {
+    for (let i = 0; i < this.availableHosts.length; i++) {
+      const host = this.availableHosts[i];
+      if (!host.failed && this.currentHostIndex !== i) {
+        this.currentHostIndex = i;
+        return Promise.resolve(host);
+      }
+    }
+    // this means all hosts have failed
+    this.currentHostIndex = 0;
+    return Promise.reject(new Error(`All hosts have failed for ${this.service}`));
   },
 
-  setAndGetNextAvailableUrl() {
-    this.cycleHost();
+  doesUrlBelongToService(uri) {
+    const urlObj = url.parse(uri);
+    const hosts = this.availableHosts.map((h) => h.host);
+    hosts.push(url.parse(this.defaultUrl).host);
+    return some(hosts, (host) => host === urlObj.host);
+  },
+
+  getCurrentUrl() {
     return this.url;
   },
 

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
@@ -86,7 +86,9 @@ const ServiceModel = AmpState.extend({
 
     if (attrs.availableHosts) {
       // ensure highest priority is at the top
-      attrs.availableHosts.sort((a, b) => a.priority > b.priority);
+      // using number value here instead boolean for IE and Edge
+      // https://github.com/tc39/ecma262/issues/902
+      attrs.availableHosts.sort((a, b) => a.priority - b.priority);
     }
 
     return attrs;

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
@@ -1,0 +1,133 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import AmpState from 'ampersand-state';
+import {defaults, isObject} from 'lodash';
+import url from 'url';
+
+const ServiceModel = AmpState.extend({
+  props: {
+    service: `string`,
+    defaultUrl: `string`,
+    availableHosts: {
+      type: `array`,
+      default() {
+        return [];
+      }
+    }
+  },
+
+  session: {
+    currentHostIndex: {
+      type: `number`,
+      default: 0
+    }
+  },
+
+  derived: {
+    url: {
+      deps: [`defaultUrl`, `availableHosts`, `currentHostIndex`],
+      fn() {
+        if (this.availableHosts.length === 0) {
+          return this.defaultUrl;
+        }
+        let host;
+        if (this.currentHostIndex >= this.availableHosts.length) {
+          host = this.availableHosts[this.availableHosts.length - 1];
+        }
+        else {
+          host = this.availableHosts[this.currentHostIndex];
+        }
+
+        return this._changeUrlHost(this.defaultUrl, host.host);
+      }
+    }
+  },
+
+  constructor(attrs, options) {
+    options = options || {};
+    defaults(options, {parse: true});
+    return Reflect.apply(AmpState.prototype.constructor, this, [attrs, options]);
+  },
+
+  idAttribute: `service`,
+
+  serialize(...args) {
+    const attrs = Reflect.apply(AmpState.prototype.serialize, this, args);
+    attrs.url = this.url;
+    return attrs;
+  },
+
+  parse(attrs) {
+    if (!attrs) {
+      return {};
+    }
+
+    if (attrs.availableHosts) {
+      // ensure highest priority is at the top
+      attrs.availableHosts.sort((a, b) => a.priority > b.priority);
+    }
+
+    return attrs;
+  },
+
+  // Override set to make sure we always run parse()
+  // See https://github.com/AmpersandJS/ampersand-state/issues/146 for related
+  // bug
+  set(key, value, options) {
+    let attrs;
+    // Handle both `"key", value` and `{key: value}` -style arguments.
+    // The next block is a direct copy from ampersand-state, so no need to test
+    // both scenarios.
+    /* istanbul ignore next */
+    if (isObject(key) || key === null) {
+      attrs = key;
+      options = value;
+    }
+    else {
+      attrs = {};
+      attrs[key] = value;
+    }
+
+    attrs = this.parse(attrs, options);
+    return Reflect.apply(AmpState.prototype.set, this, [attrs, options]);
+  },
+
+  markHostFailed() {
+    const currentHost = this.getCurrentHost();
+    currentHost.failed = true;
+  },
+
+  cycleHost() {
+    this.currentHostIndex += 1;
+    if (this.currentHostIndex >= this.availableHosts.length) {
+      this.currentHostIndex = 0;
+    }
+  },
+
+  getCurrentUrl() {
+    return this.url;
+  },
+
+  setAndGetNextAvailableUrl() {
+    this.cycleHost();
+    return this.url;
+  },
+
+  getCurrentHost() {
+    return this.availableHosts[this.currentHostIndex];
+  },
+
+  replaceUrlWithCurrentHost(uri) {
+    return this._changeUrlHost(uri, this.getCurrentHost().host);
+  },
+
+  _changeUrlHost(currentUrl, host) {
+    const urlObj = url.parse(currentUrl);
+    urlObj.host = host;
+    return url.format(urlObj);
+  }
+});
+
+export default ServiceModel;

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/index.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/index.js
@@ -27,6 +27,8 @@ export {default as Device} from './device';
 export {default as FeaturesModel} from './device/features-model';
 export {default as FeatureCollection} from './device/feature-collection';
 export {default as FeatureModel} from './device/feature-model';
+export {default as ServiceCollection} from './device/service-collection';
+export {default as ServiceModel} from './device/service-model';
 export {default as EmbargoInterceptor} from './interceptors/embargo';
 export {default as UrlInterceptor} from './interceptors/url';
 export {default as DeviceUrlInterceptor} from './interceptors/device-url';

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/device.js
@@ -31,6 +31,9 @@ describe(`plugin-wdm`, function() {
           assert.property(spark.internal.device, `url`);
           assert.property(spark.internal.device, `userId`);
           assert.property(spark.internal.device, `webSocketUrl`);
+          assert.property(spark.internal.device, `serviceHostMap`);
+          assert.property(spark.internal.device.serviceHostMap, `serviceLinks`);
+          assert.property(spark.internal.device.serviceHostMap, `hostCatalog`);
         }));
     });
 
@@ -50,6 +53,9 @@ describe(`plugin-wdm`, function() {
             assert.property(spark.internal.device, `url`);
             assert.property(spark.internal.device, `userId`);
             assert.property(spark.internal.device, `webSocketUrl`);
+            assert.property(spark.internal.device, `serviceHostMap`);
+            assert.property(spark.internal.device.serviceHostMap, `hostCatalog`);
+            assert.property(spark.internal.device.serviceHostMap, `serviceLinks`);
             assert.notEqual(spark.internal.device.modificationTime, modificationTime);
             assert.equal(spark.internal.device.url, url, `Refreshing the device without sending the entire original payload must not give us a new registration`);
           });

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/lib/device-fixture.json
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/lib/device-fixture.json
@@ -10,6 +10,7 @@
     "filesServiceUrl": "https://beta.webex.com/files/api/v1",
     "locusServiceUrl": "https://locus-a.wbx2.com/locus/api/v1",
     "metricsServiceUrl": "https://metrics-a.wbx2.com/metrics/api/v1",
+    "mercuryConnectionServiceUrl": "https://mercury-connection-a.wbx2.com/v1",
     "squaredFilesServiceUrl": "https://files-api-a.wbx2.com/v1"
   },
   "deviceType": "DESKTOP",
@@ -21,6 +22,30 @@
   "capabilities": {
     "groupCallSupported": false,
     "sdpSupported": false
+  },
+  "serviceHostMap": {
+    "serviceLinks": {
+        "mercuryConnection": "wss://mercury-connection-a.wbx2.com/v1"
+    },
+    "hostCatalog": {
+        "mercury-connection-a.wbx2.com": [
+          {
+            "host": "mercury-connection-a4.wbx2.com",
+            "ttl": -1,
+            "priority": 7
+          },
+          {
+            "host": "mercury-connection-a5.wbx2.com",
+            "ttl": -1,
+            "priority": 6
+          },
+          {
+            "host": "mercury-connection.a6.ciscospark.com",
+             "ttl": -1,
+             "priority": 5
+          }
+        ]
+    }
   },
   "features": {
     "developer": [

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/lib/device-fixture.json
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/lib/device-fixture.json
@@ -44,6 +44,18 @@
              "ttl": -1,
              "priority": 5
           }
+        ],
+        "conv-a.wbx2.com": [
+          {
+            "host": "conv-a5.wbx2.com",
+            "ttl": -1,
+            "priority": 5
+          },
+          {
+            "host": "conv-a4.wbx2.com",
+            "ttl": -1,
+            "priority": 4
+          }
         ]
     }
   },

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
@@ -102,17 +102,27 @@ describe(`plugin-wdm`, () => {
         ]);
       });
 
-      describe(`when web-ha-messasing is enabled`, () => {
-        it(`returns the service url with a different host if available`, () => {
-          console.log(device.features.developer);
+      describe(`when web-ha-messaging is enabled`, () => {
+        beforeEach(`enable web-ha-messaging`, () => {
           device.features.developer.set([{
-            key: `web-ha-messasing`,
+            key: `web-ha-messaging`,
             val: `true`,
             value: true,
             mutable: true,
             lastModified: `2015-06-29T20:02:48.033Z`
           }]);
+        });
 
+        it(`returns the default service url by default`, () => {
+          device.services = {
+            validServiceUrl: `http://example.com/valid-service`,
+            anotherServiceUrl: `http://another.com/another-service`
+          };
+
+          return assert.becomes(device.getServiceUrl(`another`), `http://another.com/another-service`);
+        });
+
+        it(`returns the service url with a different host if available`, () => {
           device.services = {
             validServiceUrl: `http://example.com/valid-service`,
             anotherServiceUrl: `http://another.com/another-service`
@@ -122,10 +132,6 @@ describe(`plugin-wdm`, () => {
             hostCatalog: {
               'another.com': [
                 {
-                  host: `another-2.com`,
-                  priority: 2
-                },
-                {
                   host: `another-1.com`,
                   priority: 1
                 }
@@ -134,12 +140,36 @@ describe(`plugin-wdm`, () => {
           };
           return assert.becomes(device.getServiceUrl(`another`), `http://another-1.com/another-service`);
         });
+
+        it(`returns the service url with a higher priority host`, () => {
+          device.services = {
+            validServiceUrl: `http://example.com/valid-service`,
+            anotherServiceUrl: `http://another.com/another-service`
+          };
+
+          device.serviceHostMap = {
+            hostCatalog: {
+              'another.com': [
+                {
+                  host: `another-low-priority.com`,
+                  priority: 2
+                },
+                {
+                  host: `another-high-priority.com`,
+                  priority: 1
+                }
+              ]
+            }
+          };
+          return assert.becomes(device.getServiceUrl(`another`), `http://another-high-priority.com/another-service`);
+        });
+
       });
 
-      describe(`when web-ha-messasing is disabled`, () => {
+      describe(`when web-ha-messaging is disabled`, () => {
         it(`disregards the host catalog and returns the normal url`, () => {
           device.features.developer.set([{
-            key: `web-ha-messasing`,
+            key: `web-ha-messaging`,
             val: `false`,
             value: false,
             mutable: true,

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
@@ -18,12 +18,22 @@ describe(`plugin-wdm`, () => {
           device: Device
         }
       });
-
       spark.internal.device.set(deviceFixture);
 
       device = spark.internal.device;
 
       device.config.preDiscoveryServices = {};
+    });
+
+    describe(`#currentWebSocketUrl`, () => {
+      it(`returns web socket url based on the availability of mercuryConnection host`, () => {
+        assert.equal(device.currentWebSocketUrl, `wss://mercury-connection.a6.ciscospark.com/v1/apps/wx2/registrations/WEBSOCKETID/messages`);
+      });
+
+      it(`returns updated web socket url when host changes`, () => {
+        return device.markUrlFailedAndGetNew(`mercuryConnection`)
+          .then(() => assert.equal(device.currentWebSocketUrl, `wss://mercury-connection-a5.wbx2.com/v1/apps/wx2/registrations/WEBSOCKETID/messages`));
+      });
     });
 
     describe(`#clear()`, () => {
@@ -84,6 +94,91 @@ describe(`plugin-wdm`, () => {
             }),
           assert.becomes(device.getServiceUrl(`valid`), `http://example.com/valid-service`)
         ]);
+      });
+
+      it(`returns the service url with a different host if available`, () => {
+        device.services = {
+          validServiceUrl: `http://example.com/valid-service`,
+          anotherServiceUrl: `http://another.com/another-service`
+        };
+
+        device.serviceHostMap = {
+          hostCatalog: {
+            'another.com': [
+              {
+                host: `another-2.com`,
+                priority: 2
+              },
+              {
+                host: `another-1.com`,
+                priority: 1
+              }
+            ]
+          }
+        };
+        return assert.becomes(device.getServiceUrl(`another`), `http://another-1.com/another-service`);
+      });
+    });
+
+    describe(`#markUrlFailedAndGetNew()`, () => {
+      it(`requires a \`service\` parameter`, () => {
+        return assert.isRejected(device.markUrlFailedAndGetNew(), /`service` is a required parameter/);
+      });
+
+      it(`returns service url for the next available host`, () => {
+        return assert.becomes(device.markUrlFailedAndGetNew(`mercuryConnection`), `https://mercury-connection-a5.wbx2.com/v1`);
+      });
+
+      it(`calls refresh to get new data if it cycled through all the hosts`, () => {
+        sinon.spy(device, `refresh`);
+        assert.notCalled(device.refresh);
+        device.services = {
+          failingServiceUrl: `http://fail.com/v1`
+        };
+        device.serviceHostMap = {
+          hostCatalog: {
+            'fail.com': [
+              {
+                host: `fail-2.com`,
+                priority: 2
+              },
+              {
+                host: `fail-1.com`,
+                priority: 1
+              }
+            ]
+          }
+        };
+
+        const request = device.spark.request;
+        assert.isTrue(device.registered);
+        request.onCall(0).returns(Promise.resolve({
+          body: {
+            services: {
+              failingServiceUrl: `http://fail.com/v1`
+            },
+            serviceHostMap: {
+              hostCatalog: {
+                'fail.com': [
+                  {
+                    host: `new-4.com`,
+                    priority: 2
+                  },
+                  {
+                    host: `new-3.com`,
+                    priority: 1
+                  }
+                ]
+              }
+            }
+          }
+        }));
+
+        return assert.becomes(device.markUrlFailedAndGetNew(`failing`), `http://fail-2.com/v1`)
+          .then(() => assert.becomes(device.markUrlFailedAndGetNew(`failing`), `http://new-3.com/v1`))
+          .then(() => {
+            assert.calledOnce(device.refresh);
+          });
       });
     });
 

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
@@ -96,28 +96,70 @@ describe(`plugin-wdm`, () => {
         ]);
       });
 
-      it(`returns the service url with a different host if available`, () => {
-        device.services = {
-          validServiceUrl: `http://example.com/valid-service`,
-          anotherServiceUrl: `http://another.com/another-service`
-        };
+      describe(`when web-ha-messasing is enabled`, () => {
+        it(`returns the service url with a different host if available`, () => {
+          console.log(device.features.developer);
+          device.features.developer.set([{
+            key: `web-ha-messasing`,
+            val: `true`,
+            value: true,
+            mutable: true,
+            lastModified: `2015-06-29T20:02:48.033Z`
+          }]);
 
-        device.serviceHostMap = {
-          hostCatalog: {
-            'another.com': [
-              {
-                host: `another-2.com`,
-                priority: 2
-              },
-              {
-                host: `another-1.com`,
-                priority: 1
-              }
-            ]
-          }
-        };
-        return assert.becomes(device.getServiceUrl(`another`), `http://another-1.com/another-service`);
+          device.services = {
+            validServiceUrl: `http://example.com/valid-service`,
+            anotherServiceUrl: `http://another.com/another-service`
+          };
+
+          device.serviceHostMap = {
+            hostCatalog: {
+              'another.com': [
+                {
+                  host: `another-2.com`,
+                  priority: 2
+                },
+                {
+                  host: `another-1.com`,
+                  priority: 1
+                }
+              ]
+            }
+          };
+          return assert.becomes(device.getServiceUrl(`another`), `http://another-1.com/another-service`);
+        });
       });
+
+      describe(`when web-ha-messasing is disabled`, () => {
+        it(`disregards the host catalog and returns the normal url`, () => {
+          device.features.developer.set([{
+            key: `web-ha-messasing`,
+            val: `false`,
+            value: false,
+            mutable: true,
+            lastModified: `2015-06-29T20:02:48.033Z`
+          }]);
+
+          device.services = {
+            validServiceUrl: `http://example.com/valid-service`,
+            anotherServiceUrl: `http://another.com/another-service`
+          };
+
+          device.serviceHostMap = {
+            hostCatalog: {
+              'another.com': [
+                {
+                  host: `another-1.com`,
+                  priority: 1
+                }
+              ]
+            }
+          };
+
+          return assert.becomes(device.getServiceUrl(`another`), `http://another.com/another-service`);
+        });
+      });
+
     });
 
     describe(`#markUrlFailedAndGetNew()`, () => {

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
@@ -25,14 +25,20 @@ describe(`plugin-wdm`, () => {
       device.config.preDiscoveryServices = {};
     });
 
-    describe(`#currentWebSocketUrl`, () => {
+    describe(`#getWebSocketUrl()`, () => {
       it(`returns web socket url based on the availability of mercuryConnection host`, () => {
-        assert.equal(device.currentWebSocketUrl, `wss://mercury-connection.a6.ciscospark.com/v1/apps/wx2/registrations/WEBSOCKETID/messages`);
+        return assert.becomes(device.getWebSocketUrl(), `wss://mercury-connection.a6.ciscospark.com/v1/apps/wx2/registrations/WEBSOCKETID/messages`);
       });
 
       it(`returns updated web socket url when host changes`, () => {
-        return device.markUrlFailedAndGetNew(`mercuryConnection`)
-          .then(() => assert.equal(device.currentWebSocketUrl, `wss://mercury-connection-a5.wbx2.com/v1/apps/wx2/registrations/WEBSOCKETID/messages`));
+        return device.markUrlFailedAndGetNew(`wss://mercury-connection.a6.ciscospark.com/v1/apps/wx2/registrations/WEBSOCKETID/messages`)
+          .then(() => assert.becomes(device.getWebSocketUrl(), `wss://mercury-connection-a5.wbx2.com/v1/apps/wx2/registrations/WEBSOCKETID/messages`));
+      });
+    });
+
+    describe(`#useServiceCatalogUrl`, () => {
+      it(`replaces current url with url from the service catalog`, () => {
+        return assert.becomes(device.useServiceCatalogUrl(`https://conv-a.wbx2.com/conversation/v1`), `https://conv-a4.wbx2.com/conversation/v1`);
       });
     });
 
@@ -163,12 +169,12 @@ describe(`plugin-wdm`, () => {
     });
 
     describe(`#markUrlFailedAndGetNew()`, () => {
-      it(`requires a \`service\` parameter`, () => {
-        return assert.isRejected(device.markUrlFailedAndGetNew(), /`service` is a required parameter/);
+      it(`requires a \`url\` parameter`, () => {
+        return assert.isRejected(device.markUrlFailedAndGetNew(), /`url` is a required parameter/);
       });
 
       it(`returns service url for the next available host`, () => {
-        return assert.becomes(device.markUrlFailedAndGetNew(`mercuryConnection`), `https://mercury-connection-a5.wbx2.com/v1`);
+        return assert.becomes(device.markUrlFailedAndGetNew(`https://mercury-connection.a6.ciscospark.com/v1`), `https://mercury-connection-a5.wbx2.com/v1`);
       });
 
       it(`calls refresh to get new data if it cycled through all the hosts`, () => {
@@ -216,8 +222,8 @@ describe(`plugin-wdm`, () => {
           }
         }));
 
-        return assert.becomes(device.markUrlFailedAndGetNew(`failing`), `http://fail-2.com/v1`)
-          .then(() => assert.becomes(device.markUrlFailedAndGetNew(`failing`), `http://new-3.com/v1`))
+        return assert.becomes(device.markUrlFailedAndGetNew(`http://fail-1.com/v1`), `http://fail-2.com/v1`)
+          .then(() => assert.becomes(device.markUrlFailedAndGetNew(`http://fail-2.com/v1`), `http://new-3.com/v1`))
           .then(() => {
             assert.calledOnce(device.refresh);
           });

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/service-collection.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/service-collection.js
@@ -1,0 +1,71 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {assert} from '@ciscospark/test-helper-chai';
+import {ServiceCollection} from '@ciscospark/internal-plugin-wdm';
+
+describe(`plugin-wdm`, () => {
+  describe(`ServiceCollections`, () => {
+    const https = `https://`;
+    const mercuryPriority0 = `mercury-connection.a6.ciscospark.com`;
+    const mercuryPriority1 = `mercury-connection-a5.wbx2.com`;
+    const mercuryPriority2 = `mercury-connection-a4.wbx2.com`;
+    let serviceCatalog;
+
+    beforeEach(`add services`, () => {
+      serviceCatalog = new ServiceCollection();
+      serviceCatalog.add([
+        {
+          service: `mercuryConnectionServiceUrl`,
+          defaultUrl: `https://mercury-connection-a.wbx2.com/v1`,
+          availableHosts: [
+            {
+              host: mercuryPriority0,
+              priority: 0
+            },
+            {
+              host: mercuryPriority2,
+              priority: 2
+            },
+            {
+              host: mercuryPriority1,
+              priority: 1
+            }]
+        },
+        {
+          service: `conversationServiceUrl`,
+          defaultUrl: `https://conv-a.wbx2.com/conversation/api/v1`,
+          availableHosts: [
+            {
+              host: `conv-a.wbx2.com`,
+              priority: 5
+            }]
+        },
+        {
+          service: `atlasServiceUrl`,
+          defaultUrl: `https://atlas-a-wbx2.com/admin/api/v1`
+        }
+      ]);
+    });
+
+    describe(`#markFailedAndCycleUrl()`, () => {
+      it(`marks current url as failed and returns another url`, () => assert.becomes(serviceCatalog.markFailedAndCycleUrl(`${https}${mercuryPriority0}`), `${https}${mercuryPriority1}/v1`)
+        .then(() => {
+          assert.isTrue(serviceCatalog.get(`mercuryConnectionServiceUrl`).availableHosts[0].failed);
+        }));
+    });
+
+    describe(`#inferServiceNameFromUrl()`, () => {
+      it(`infers service from url`, () => {
+        return assert.becomes(serviceCatalog.inferServiceNameFromUrl(`https://mercury-connection.a6.ciscospark.com/v1`), `mercuryConnectionServiceUrl`)
+          .then(() => assert.becomes(serviceCatalog.inferServiceNameFromUrl(`https://conv-a.wbx2.com/conversation/v1`), `conversationServiceUrl`));
+      });
+
+      it(`rejects when cannot infer service from url`, () => {
+        return assert.isRejected(serviceCatalog.inferServiceNameFromUrl(`https://example-404.com`));
+      });
+
+    });
+  });
+});

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/service-model.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/service-model.js
@@ -1,0 +1,80 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {assert} from '@ciscospark/test-helper-chai';
+import {ServiceModel} from '@ciscospark/internal-plugin-wdm';
+
+describe(`plugin-wdm`, () => {
+  describe(`ServiceModel`, () => {
+    const https = `https://`;
+    const mercuryPriority0 = `mercury-connection.a6.ciscospark.com`;
+    const mercuryPriority1 = `mercury-connection-a5.wbx2.com`;
+    const mercuryPriority2 = `mercury-connection-a4.wbx2.com`;
+    let mercuryService;
+    let atlasService;
+
+    beforeEach(`create services`, () => {
+      mercuryService = new ServiceModel({
+        service: `mercuryConnectionServiceUrl`,
+        defaultUrl: `https://mercury-connection-a.wbx2.com/v1`,
+        availableHosts: [
+          {
+            host: mercuryPriority0,
+            priority: 0
+          },
+          {
+            host: mercuryPriority2,
+            priority: 2
+          },
+          {
+            host: mercuryPriority1,
+            priority: 1
+          }]
+      });
+
+      atlasService = new ServiceModel({
+        service: `atlasServiceUrl`,
+        defaultUrl: `https://atlas-a-wbx2.com/admin/api/v1`
+      });
+    });
+
+    it(`sorts availableHosts by highest priority first`, () => {
+      assert.equal(mercuryService.availableHosts[0].priority, 0);
+      assert.equal(mercuryService.availableHosts[1].priority, 1);
+      assert.equal(mercuryService.availableHosts[2].priority, 2);
+    });
+
+    it(`returns default service url`, () => {
+      assert.equal(atlasService.url, `https://atlas-a-wbx2.com/admin/api/v1`);
+    });
+
+    it(`returns translated service url by the highest priority host`, () => {
+      assert.equal(mercuryService.url, `${https}${mercuryPriority0}/v1`);
+    });
+
+    describe(`#setAndGetNextAvailableUrl()`, () => {
+      it(`returns the next priority url`, () => {
+        assert.equal(mercuryService.url, `${https}${mercuryPriority0}/v1`);
+        assert.equal(mercuryService.setAndGetNextAvailableUrl(), `${https}${mercuryPriority1}/v1`);
+        assert.equal(mercuryService.setAndGetNextAvailableUrl(), `${https}${mercuryPriority2}/v1`);
+        assert.equal(mercuryService.setAndGetNextAvailableUrl(), `${https}${mercuryPriority0}/v1`);
+        assert.equal(mercuryService.setAndGetNextAvailableUrl(), `${https}${mercuryPriority1}/v1`);
+      });
+    });
+
+    describe(`#getCurrentHost()`, () => {
+      it(`returns the current host`, () => {
+        assert.equal(mercuryService.getCurrentHost().host, mercuryPriority0);
+      });
+    });
+
+    describe(`#replaceUrlWithCurrentHost()`, () => {
+      it(`replaces the url with the current host`, () => {
+        mercuryService.setAndGetNextAvailableUrl();
+        assert.equal(mercuryService.getCurrentHost().host, mercuryPriority1);
+        assert.equal(mercuryService.replaceUrlWithCurrentHost(`https://example.com/v1`), `${https}${mercuryPriority1}/v1`);
+      });
+    });
+  });
+});

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/service-model.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/service-model.js
@@ -53,13 +53,42 @@ describe(`plugin-wdm`, () => {
       assert.equal(mercuryService.url, `${https}${mercuryPriority0}/v1`);
     });
 
-    describe(`#setAndGetNextAvailableUrl()`, () => {
-      it(`returns the next priority url`, () => {
+    describe(`#markHostFailed`, () => {
+      it(`marks current host as failed`, () => {
+        assert.isNotOk(mercuryService.getCurrentHost().failed);
+        mercuryService.markHostFailed();
+        assert.isTrue(mercuryService.getCurrentHost().failed);
+      });
+
+      it(`marks a host as failed`, () => {
+        assert.isNotOk(mercuryService.availableHosts[1].failed);
+        mercuryService.markHostFailed(`${https}${mercuryPriority1}/v1`);
+        assert.isTrue(mercuryService.availableHosts[1].failed);
+      });
+    });
+
+    describe(`#cycleNextHost()`, () => {
+      it(`returns next priority host that has not yet failed`, () => {
         assert.equal(mercuryService.url, `${https}${mercuryPriority0}/v1`);
-        assert.equal(mercuryService.setAndGetNextAvailableUrl(), `${https}${mercuryPriority1}/v1`);
-        assert.equal(mercuryService.setAndGetNextAvailableUrl(), `${https}${mercuryPriority2}/v1`);
-        assert.equal(mercuryService.setAndGetNextAvailableUrl(), `${https}${mercuryPriority0}/v1`);
-        assert.equal(mercuryService.setAndGetNextAvailableUrl(), `${https}${mercuryPriority1}/v1`);
+        mercuryService.markHostFailed();
+        return assert.isFulfilled(mercuryService.cycleNextHost())
+          .then(() => {
+            assert.equal(mercuryService.url, `${https}${mercuryPriority1}/v1`);
+          });
+      });
+
+      it(`rejects when all hosts have failed`, () => {
+        for (let i = 0; i < mercuryService.availableHosts.length; i++) {
+          mercuryService.availableHosts[i].failed = true;
+        }
+        return assert.isRejected(mercuryService.cycleNextHost());
+      });
+    });
+
+    describe(`#doesUrlBelongToService()`, () => {
+      it(`returns true when url belongs to this service`, () => {
+        assert.isTrue(mercuryService.doesUrlBelongToService(`${https}${mercuryPriority0}/stuff`));
+        assert.isTrue(atlasService.doesUrlBelongToService(`https://atlas-a-wbx2.com/admin/api/v1`));
       });
     });
 
@@ -71,7 +100,7 @@ describe(`plugin-wdm`, () => {
 
     describe(`#replaceUrlWithCurrentHost()`, () => {
       it(`replaces the url with the current host`, () => {
-        mercuryService.setAndGetNextAvailableUrl();
+        mercuryService.cycleNextHost();
         assert.equal(mercuryService.getCurrentHost().host, mercuryPriority1);
         assert.equal(mercuryService.replaceUrlWithCurrentHost(`https://example.com/v1`), `${https}${mercuryPriority1}/v1`);
       });

--- a/packages/node_modules/@ciscospark/test-helper-mock-spark/src/index.js
+++ b/packages/node_modules/@ciscospark/test-helper-mock-spark/src/index.js
@@ -190,6 +190,7 @@ function makeSpark(options) {
     conversation: {},
     device: {
       webSocketUrl: 'ws://example.com',
+      currentWebSocketUrl: 'ws://example.com',
       features: {
         developer: {
           get: sinon.stub()

--- a/packages/node_modules/@ciscospark/test-helper-mock-spark/src/index.js
+++ b/packages/node_modules/@ciscospark/test-helper-mock-spark/src/index.js
@@ -190,7 +190,7 @@ function makeSpark(options) {
     conversation: {},
     device: {
       webSocketUrl: 'ws://example.com',
-      currentWebSocketUrl: 'ws://example.com',
+      getWebSocketUrl: sinon.stub().returns(Promise.resolve('ws://example-2.com')),
       features: {
         developer: {
           get: sinon.stub()


### PR DESCRIPTION
- feature toggle `web-ha-messaging`
- when we get a new catalog, we parse service and serviceHostMap and
  encapsulate into serviceCatalog collection
- getWebSocketUrl should now replace webSocketUrl due to its ability
  to take datacenter availability into account
- add new method to mark current service url as fail and get a new one,
  it cycles through all the host and when all hosts fail, it requests
  new service registration info from wdm