### PR TITLE
build(npm): disable package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Greenkeeper does not play as nicely with package-lock.json as we would like, so this disables it for the timebeing