### PR TITLE
fix(@ciscospark/test-helper-test-users): assert the correct access_token

### DIFF
--- a/packages/node_modules/@ciscospark/test-helper-test-users/src/index.js
+++ b/packages/node_modules/@ciscospark/test-helper-test-users/src/index.js
@@ -96,7 +96,7 @@ function _extractFromEnv(options) {
   }
 
   for (var j = 0; j < count; j++) {
-    assert(users[j].access_token, 'No access token available for user' + j);
+    assert(users[j].token.access_token, 'No access token available for user' + j);
   }
 
   return users;


### PR DESCRIPTION
on line 86, token is being pushed in as
```javascript
users.push({
  token: {
    access_token: process.env['CISCOSPARK_ACCESS_TOKEN_' + i]
  }
})
```

so the assert should be `assert(users[j].token.access_token`