### PR TITLE
fix(@ciscospark/spark-core): catch token revocation failure

### DIFF
--- a/packages/node_modules/@ciscospark/spark-core/src/interceptors/auth.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/interceptors/auth.js
@@ -39,7 +39,7 @@ export default class AuthInterceptor extends Interceptor {
           return options;
         }
 
-        return this.spark.credentials.getUserToken(this.spark.config.credentials.scope)
+        return this.spark.credentials.getUserToken()
           .then((token) => {
             options.headers.authorization = token.toString();
             return options;

--- a/packages/node_modules/@ciscospark/spark-core/src/lib/credentials/credentials.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/lib/credentials/credentials.js
@@ -13,7 +13,7 @@ import {
   whileInFlight
 } from '@ciscospark/common';
 import {safeSetTimeout} from '@ciscospark/common-timers';
-import {cloneDeep, isObject} from 'lodash';
+import {clone, cloneDeep, isObject} from 'lodash';
 
 import SparkPlugin from '../spark-plugin';
 import {persist, waitForValue} from '../storage/decorators';
@@ -383,7 +383,7 @@ const Credentials = SparkPlugin.extend({
     this.logger.info('credentials: refresh requested');
 
     const supertoken = this.supertoken;
-    const tokens = this.userTokens.models;
+    const tokens = clone(this.userTokens.models);
 
     // This is kind of a leaky abstraction, since it relies on the authorization
     // plugin, but the only alternatives I see are
@@ -403,17 +403,20 @@ const Credentials = SparkPlugin.extend({
           clearTimeout(this.refreshTimer);
           this.unset('refreshTimer');
         }
-        this.userTokens.reset();
         this.supertoken = st;
-        return Promise.all(tokens.map((token) => {
-          this.logger.info(`credentials: revoking token for ${token.scope}`);
-          return this.downscope(token.scope)
-            // eslint-disable-next-line max-nested-callbacks
-            .then((t) => {
-              this.userTokens.add(t);
-              token.revoke();
-            });
-        }));
+        return Promise.all(tokens.map((token) => this.downscope(token.scope)
+          // eslint-disable-next-line max-nested-callbacks
+          .then((t) => {
+            this.logger.info(`credentials: revoking token for ${token.scope}`);
+            return token.revoke()
+              .catch((err) => {
+                this.logger.warn('credentials: failed to revoke user token', err);
+              })
+              .then(() => {
+                this.userTokens.remove(token.scope);
+                this.userTokens.add(t);
+              });
+          })));
       })
       .then(() => {
         this.scheduleRefresh(this.supertoken.expires);

--- a/packages/node_modules/@ciscospark/spark-core/test/unit/spec/credentials/credentials.js
+++ b/packages/node_modules/@ciscospark/spark-core/test/unit/spec/credentials/credentials.js
@@ -559,7 +559,7 @@ describe('spark-core', () => {
     });
 
     describe('#refresh()', () => {
-      it('refreshes and downscopes the supertoken', () => {
+      it('refreshes and downscopes the supertoken, and revokes previous tokens', () => {
         const spark = new MockSpark();
         const credentials = new Credentials(undefined, {parent: spark});
         spark.trigger('change:config');
@@ -585,6 +585,7 @@ describe('spark-core', () => {
 
         sinon.stub(st2, 'downscope').returns(Promise.resolve(t2));
         sinon.stub(st, 'refresh').returns(Promise.resolve(st2));
+        sinon.stub(t1, 'revoke').returns(Promise.resolve());
         sinon.spy(credentials, 'scheduleRefresh');
 
         credentials.set({
@@ -598,6 +599,53 @@ describe('spark-core', () => {
         return credentials.refresh()
           .then(() => assert.called(st.refresh))
           .then(() => assert.calledWith(st2.downscope, 'scope1'))
+          .then(() => assert.called(t1.revoke))
+          .then(() => assert.isUndefined(credentials.userTokens.get(t1.scope)))
+          .then(() => assert.equal(credentials.userTokens.get(t2.scope), t2))
+          .then(() => assert.calledWith(credentials.scheduleRefresh, st.expires));
+      });
+
+      it('refreshes and downscopes the supertoken even if revocation of previous token fails', () => {
+        const spark = new MockSpark();
+        const credentials = new Credentials(undefined, {parent: spark});
+        spark.trigger('change:config');
+        const st = makeToken(spark, {
+          access_token: 'ST',
+          refresh_token: 'RT'
+        });
+
+        const st2 = makeToken(spark, {
+          access_token: 'ST2',
+          refresh_token: 'RT2'
+        });
+
+        const t1 = makeToken(spark, {
+          access_token: 'AT1',
+          scope: 'scope1'
+        });
+
+        const t2 = makeToken(spark, {
+          access_token: 'AT2',
+          scope: 'scope2'
+        });
+
+        sinon.stub(st2, 'downscope').returns(Promise.resolve(t2));
+        sinon.stub(st, 'refresh').returns(Promise.resolve(st2));
+        sinon.stub(t1, 'revoke').returns(Promise.reject());
+        sinon.spy(credentials, 'scheduleRefresh');
+
+        credentials.set({
+          supertoken: st,
+          userTokens: [
+            t1
+          ]
+        });
+
+        assert.equal(credentials.userTokens.get(t1.scope), t1);
+        return credentials.refresh()
+          .then(() => assert.called(st.refresh))
+          .then(() => assert.calledWith(st2.downscope, 'scope1'))
+          .then(() => assert.called(t1.revoke))
           .then(() => assert.isUndefined(credentials.userTokens.get(t1.scope)))
           .then(() => assert.equal(credentials.userTokens.get(t2.scope), t2))
           .then(() => assert.calledWith(credentials.scheduleRefresh, st.expires));


### PR DESCRIPTION
if token.revoke fails, credentials.refresh() should still succeed. failure happens when there is an old token that was not cleaned up when logging out
  
I think this PR also addresses the error when logging out: https://github.com/ciscospark/spark-js-sdk/pull/796, but might be good to have both changes in. Even if token.revoke fails for a different reason, we still want credentials.refresh() to succeed