### PR TITLE
fix(@ciscospark/helper-image): copy from buffer using Buffer.from

### DIFF
--- a/packages/node_modules/@ciscospark/helper-image/src/index.js
+++ b/packages/node_modules/@ciscospark/helper-image/src/index.js
@@ -48,11 +48,7 @@ export function updateImageOrientation(file) {
     reader.readAsArrayBuffer(file);
     reader.onload = function onload() {
       const arrayBuffer = reader.result;
-      const buf = Buffer.from(arrayBuffer.byteLength);
-      const view = new Uint8Array(arrayBuffer);
-      for (let i = 0; i < buf.length; i += 1) {
-        buf[i] = view[i];
-      }
+      const buf = Buffer.from(arrayBuffer);
       resolve(buf);
     };
   })


### PR DESCRIPTION
Previously we use `new Buffer(byteLength)` to instantiate a new buffer,
then copy from our file arrayBuffer to this new buffer. 
https://github.com/ciscospark/spark-js-sdk/blob/d16dadc8a80f6760eaa28270c13a299b179e4f26/packages/node_modules/%40ciscospark/helper-image/src/index.js#L50-L56

Since `new Buffer` is deprecated, using `Buffer.from` should produce the desired behavior