### PR TITLE
feat(@ciscospark/i-p-board): channel keep alive

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/src/board.js
@@ -182,6 +182,18 @@ const Board = SparkPlugin.extend({
   },
 
   /**
+   * Keeps a channel as 'active' to prevent other people from deleting it
+   * @param  {Board~Channel} channel
+   * @returns {Promise}
+   */
+  keepActive(channel) {
+    return this.spark.request({
+      method: 'POST',
+      uri: `${channel.channelUrl}/keepAlive`
+    });
+  },
+
+  /**
    * Decrypts a collection of content objects
    *
    * @memberof Board.BoardService

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/integration/spec/board.js
@@ -521,5 +521,23 @@ describe('plugin-board', () => {
           });
       });
     });
+
+    describe('#keepActive()', () => {
+      it('keeps a channel status as active', () => {
+        let newChannel;
+        return participants[1].spark.internal.board.createChannel(conversation)
+          .then((res) => {
+            newChannel = res;
+            return participants[1].spark.internal.board.keepActive(newChannel);
+          })
+          .then(() => assert.isRejected(participants[0].spark.internal.board.deleteChannel(
+            conversation,
+            newChannel,
+            {
+              preventDeleteActiveChannel: true
+            }
+          )));
+      });
+    });
   });
 });

--- a/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-board/test/unit/spec/board.js
@@ -286,6 +286,19 @@ describe('plugin-board', () => {
     });
   });
 
+  describe('#keepActive()', () => {
+    it('requests POST to keep channel status active', () => {
+      spark.request.resetHistory();
+      return spark.internal.board.keepActive(channel)
+        .then(() => {
+          assert.calledWith(spark.request, sinon.match({
+            method: 'POST',
+            uri: `${channel.channelUrl}/keepAlive`
+          }));
+        });
+    });
+  });
+
   describe('#deleteAllContent()', () => {
     before(() => {
       spark.request.resetHistory();


### PR DESCRIPTION
If the board is opened by the user and there is no further user activity on it, we can use this event to mark it as still being used and prevent other users from deleting it