### PR TITLE
fix(@ciscospark/i-p-conversation): allow markdown when creating 1:1

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -70,6 +70,7 @@ const Conversation = SparkPlugin.extend({
    * @param {Array<Participant>} params.participants
    * @param {Array<File>} params.files
    * @param {string} params.comment
+   * @param {string} params.html
    * @param {Object} params.displayName
    * @param {Object} options
    * @param {Boolean} options.allowPartialCreation
@@ -464,7 +465,7 @@ const Conversation = SparkPlugin.extend({
   },
 
   /**
-   * Handles incoming conversatin.activity mercury messages
+   * Handles incoming conversation.activity mercury messages
    * @param {Event} event
    * @returns {Promise}
    */
@@ -873,8 +874,8 @@ const Conversation = SparkPlugin.extend({
       user: params.participants[1]
     }), Object.assign(options, {includeConvWithDeletedUserUUID: true, includeParticipants: true}))
       .then((conversation) => {
-        if (params.comment) {
-          return this.post(conversation, {displayName: params.comment})
+        if (params.comment || params.html) {
+          return this.post(conversation, {content: params.html, displayName: params.comment})
             .then((activity) => {
               conversation.activities.items.push(activity);
               return conversation;
@@ -927,6 +928,7 @@ const Conversation = SparkPlugin.extend({
     if (params.comment) {
       payload.activities.items.push(this.expand('post', {
         objectType: 'comment',
+        content: params.html,
         displayName: params.comment
       }));
     }

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/create.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/create.js
@@ -3,7 +3,6 @@
  */
 
 import {InvalidUserCreation} from '@ciscospark/internal-plugin-conversation';
-
 import {patterns} from '@ciscospark/common';
 import CiscoSpark, {SparkHttpError} from '@ciscospark/spark-core';
 import {assert} from '@ciscospark/test-helper-chai';
@@ -27,6 +26,13 @@ describe('plugin-conversation', function () {
             authorization: spock.token
           }
         });
+
+        spark.config.conversation.allowedOutboundTags = {
+          strong: []
+        };
+        spark.config.conversation.allowedInboundTags = {
+          strong: []
+        };
 
         mccoy.spark = new CiscoSpark({
           credentials: {
@@ -102,6 +108,16 @@ describe('plugin-conversation', function () {
               assert.equal(conversation.activities.items[0].verb, 'post');
               assert.equal(conversation.activities.items[0].object.displayName, 'hi');
             })));
+
+        it('returns the preexisting conversation and posts a comment with html', () => spark.internal.conversation.create({participants: [checkov], comment: '**hi**', html: '<strong>hi</strong>'})
+          .then((conversation) => spark.internal.conversation.create({participants: [checkov]})
+            .then((conversation2) => {
+              assert.equal(conversation2.url, conversation.url);
+              assert.lengthOf(conversation.activities.items, 1);
+              assert.equal(conversation.activities.items[0].verb, 'post');
+              assert.equal(conversation.activities.items[0].object.displayName, '**hi**');
+              assert.equal(conversation.activities.items[0].object.content, '<strong>hi</strong>');
+            })));
       });
 
       describe('when {forceGrouped: true} is specified', () => {
@@ -162,6 +178,13 @@ describe('plugin-conversation', function () {
     it('creates a conversation with a comment', () => spark.internal.conversation.create({comment: 'comment', participants})
       .then((c) => spark.internal.conversation.get(c, {activitiesLimit: 2}))
       .then((c) => assert.equal(c.activities.items[1].object.displayName, 'comment')));
+
+    it('creates a conversation with a comment with html', () => spark.internal.conversation.create({comment: '**comment**', html: '<strong>comment</strong>', participants})
+      .then((c) => spark.internal.conversation.get(c, {activitiesLimit: 2}))
+      .then((c) => {
+        assert.equal(c.activities.items[1].object.displayName, '**comment**');
+        assert.equal(c.activities.items[1].object.content, '<strong>comment</strong>');
+      }));
 
     it('creates a conversation with a share', () => spark.internal.conversation.create({participants, files: [sampleTextOne]})
       .then((c) => spark.internal.conversation.get(c, {activitiesLimit: 10}))


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes posting markdown when creating a 1:1 space. Previously, it only took `displayName`. However, it needs to handle `content` for markdown.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] send a markdown message when creating a 1:1 space

**Test Configuration**:
* SDK Version
* Node/Browser Version: 8.9.4
* NPM Version: 5.6.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
