### PR TITLE
feat(@ciscospark/i-p-team): handle teamRoomStatus decryption

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-team/src/index.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-team/src/index.js
@@ -2,18 +2,29 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import {isArray} from 'lodash';
-import {registerInternalPlugin} from '@ciscospark/spark-core';
-import Team from './team';
-import config from './config';
-
 import '@ciscospark/internal-plugin-conversation';
 import '@ciscospark/internal-plugin-user';
 import '@ciscospark/internal-plugin-encryption';
+import {isArray, has, get} from 'lodash';
+import {registerInternalPlugin} from '@ciscospark/spark-core';
+
+import Team from './team';
+import config from './config';
 
 registerInternalPlugin('team', Team, {
   payloadTransformer: {
-    predicates: [],
+    predicates: [
+      {
+        name: 'decryptTeamRoomStatus',
+        direction: 'inbound',
+        test(ctx, optionsOrResponse) {
+          return Promise.resolve(has(optionsOrResponse, 'activity.object.activityEvent') && get(optionsOrResponse, 'activity.object.objectType') === 'teamRoomStatus');
+        },
+        extract(optionsOrResponse) {
+          return Promise.resolve(optionsOrResponse.activity.object);
+        }
+      }
+    ],
     transforms: [
       {
         name: 'decryptTeam',
@@ -33,6 +44,14 @@ registerInternalPlugin('team', Team, {
           }
 
           return Promise.all(promises);
+        }
+      },
+      {
+        name: 'decryptTeamRoomStatus',
+        direction: 'inbound',
+        fn(ctx, teamRoomStatus) {
+          const keyUrl = get(teamRoomStatus, 'activityEvent.encryptionKeyUrl');
+          return ctx.transform('decryptObject', keyUrl, teamRoomStatus.activityEvent);
         }
       },
       {

--- a/packages/node_modules/@ciscospark/internal-plugin-team/test/integration/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-team/test/integration/spec/mercury.js
@@ -1,0 +1,97 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import '@ciscospark/internal-plugin-wdm';
+import '@ciscospark/internal-plugin-team';
+
+import {assert} from '@ciscospark/test-helper-chai';
+import CiscoSpark from '@ciscospark/spark-core';
+import {expectActivity} from '@ciscospark/test-helper-mocha';
+import {get} from 'lodash';
+import testUsers from '@ciscospark/test-helper-test-users';
+import uuid from 'uuid';
+
+describe('plugin-team', () => {
+  describe('Team', () => {
+    let kirk, spock;
+
+    before('create users', () => testUsers.create({count: 2})
+      .then((users) => {
+        [kirk, spock] = users;
+
+        kirk.spark = new CiscoSpark({
+          credentials: {
+            authorization: kirk.token
+          },
+          config: {
+            conversation: {
+              keepEncryptedProperties: true
+            }
+          }
+        });
+
+        spock.spark = new CiscoSpark({
+          credentials: {
+            authorization: spock.token
+          },
+          config: {
+            conversation: {
+              keepEncryptedProperties: true
+            }
+          }
+        });
+
+        return Promise.all([
+          kirk.spark.internal.mercury.connect(),
+          spock.spark.internal.mercury.connect()
+        ]);
+      }));
+
+    after(() => Promise.all([
+      kirk && kirk.spark.internal.mercury.disconnect(),
+      spock && spock.spark.internal.mercury.disconnect()
+    ]));
+
+    describe('when mercury event is received', () => {
+      let teamConvo, team;
+      before('create team', () => kirk.spark.internal.team.create({
+        displayName: `team-${uuid.v4()}`,
+        participants: [
+          kirk,
+          spock
+        ]
+      })
+        .then((t) => {
+          team = t;
+        }));
+
+      before('create team conversation', () => kirk.spark.internal.team.createConversation(team, {
+        displayName: `team-conversation-${uuid.v4()}`,
+        participants: [
+          kirk
+        ]
+      })
+        .then((c) => {
+          teamConvo = c;
+        }));
+
+      it('updates the displayName of an unjoined team convo', () => {
+        const update = {
+          displayName: `updated-team-convo--${uuid.v4()}`,
+          objectType: 'conversation'
+        };
+
+        const activityChecker = (activity) => activity.verb === 'update' && get(activity, 'object.objectType') === 'teamRoomStatus';
+
+        return Promise.all([
+          expectActivity(20000, 'event:conversation.activity', spock.spark.internal.mercury, activityChecker, 'teamRoomStatus update expected'),
+          kirk.spark.internal.team.update(teamConvo, update)
+        ])
+          .then(([activity]) => {
+            assert.equal(activity.object.activityEvent.object.displayName, update.displayName);
+          });
+      });
+    });
+  });
+});

--- a/packages/node_modules/@ciscospark/test-helper-mocha/src/index.js
+++ b/packages/node_modules/@ciscospark/test-helper-mocha/src/index.js
@@ -148,6 +148,54 @@ module.exports = {
   },
 
   /**
+   * @param {number} max
+   * @param {string} event
+   * @param {EventEmitter} emitter
+   * @param {function} activityChecker // callback to check if activity matches
+   * @param {string} msg
+   * @returns {Promise<mixed>} Resolves with the activity
+   */
+  expectActivity: function expectActivity(max, event, emitter, activityChecker, msg) {
+    let timer;
+
+    /**
+     * helper
+     * @private
+     * @returns {undefined}
+     */
+    function unbind() {
+      try {
+        clearTimeout(timer);
+        emitter.off(event);
+      }
+      catch (err) {
+        // ignore
+      }
+    }
+
+    return Promise.race([
+      new Promise((resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`${event} did not fire within ${max}ms${msg ? `: ${msg}` : ''}`));
+        }, max);
+      }),
+      new Promise((resolve) => {
+        emitter.on(event, (result) => {
+          const {data: {activity}} = result;
+          if (activityChecker(activity)) {
+            unbind();
+            resolve(activity);
+          }
+        });
+      })
+    ])
+      .catch((reason) => {
+        unbind();
+        throw reason;
+      });
+  },
+
+  /**
    * Returns a promise that resolves when event is fired count times or rejects
    * when max expires
    * @param {number} max


### PR DESCRIPTION
## Description

There is a new activity event with teamRoomStatus object type. https://sqbu-github.cisco.com/gist/brialam/6702e04c04f59fd97526b0fb3caaee36 This PR handles the decryption of this new objectType

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] create team with user A and user B, create team space with user A. User A changes the display name for the teams space. User B should receive the teamRoomStatus activity with the display name decrypted

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
