### PR TITLE
Add ability to provide more options to appid user

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/ping.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/ping.js
@@ -53,11 +53,11 @@ describe('plugin-wdm', function () {
         'lyra',
         'proximity',
         'voicemail',
-        'acl',
-        'mercuryAlternateDC'
+        'acl'
       ];
 
       const decommissionedServices = [
+        'mercuryAlternateDC',
         'stickies'
       ];
 

--- a/packages/node_modules/@ciscospark/plugin-authorization-browser/test/integration/spec/authorization.js
+++ b/packages/node_modules/@ciscospark/plugin-authorization-browser/test/integration/spec/authorization.js
@@ -3,36 +3,39 @@
  */
 
 import '@ciscospark/plugin-authorization-node';
-import {browserOnly, snoozeUntil} from '@ciscospark/test-helper-mocha';
+import {browserOnly} from '@ciscospark/test-helper-mocha';
 import {assert} from '@ciscospark/test-helper-chai';
 import {createUser} from '@ciscospark/test-helper-appid';
 import CiscoSpark from '@ciscospark/spark-core';
 import uuid from 'uuid';
 
-const jwtSnooze = snoozeUntil('2018-01-16T00:00', 'JWT API methods are non-functional at this time');
-
 browserOnly(describe)('plugin-authorization-browser', () => {
   describe('Authorization', () => {
     describe('#requestAccessTokenFromJwt', () => {
-      jwtSnooze(it)('exchanges a JWT for an appid access token', () => createUser({subject: `test-${uuid.v4()}`})
-        .then(({jwt}) => {
-          const spark = new CiscoSpark();
-          return spark.authorization.requestAccessTokenFromJwt({jwt})
-            .then(() => assert.isTrue(spark.canAuthorize));
-        }));
+      it('exchanges a JWT for an appid access token', () => {
+        const userId = uuid.v4();
+        const displayName = `test-${userId}`;
+        return createUser({displayName, userId})
+          .then(({jwt}) => {
+            const spark = new CiscoSpark();
+            return spark.authorization.requestAccessTokenFromJwt({jwt})
+              .then(() => assert.isTrue(spark.canAuthorize));
+          });
+      });
     });
 
     describe('\'#refresh', () => {
       describe('when used with an appid access token', () => {
-        jwtSnooze(it)('refreshes the access token', () => {
-          const subject = `test-${uuid.v4()}`;
-          return createUser({subject})
+        it('refreshes the access token', () => {
+          const userId = uuid.v4();
+          const displayName = `test-${userId}`;
+          return createUser({displayName, userId})
             .then(({jwt}) => {
               const spark = new CiscoSpark({
                 config: {
                   credentials: {
                     jwtRefreshCallback() {
-                      return createUser({subject})
+                      return createUser({displayName, userId})
                         .then(({jwt}) => jwt);
                     }
                   }

--- a/packages/node_modules/@ciscospark/plugin-authorization-node/test/integration/spec/authorization.js
+++ b/packages/node_modules/@ciscospark/plugin-authorization-node/test/integration/spec/authorization.js
@@ -3,7 +3,7 @@
  */
 
 import '@ciscospark/plugin-authorization-node';
-import {nodeOnly, snoozeUntil} from '@ciscospark/test-helper-mocha';
+import {nodeOnly} from '@ciscospark/test-helper-mocha';
 import {assert} from '@ciscospark/test-helper-chai';
 import testUsers from '@ciscospark/test-helper-test-users';
 import {createUser} from '@ciscospark/test-helper-appid';
@@ -12,8 +12,6 @@ import uuid from 'uuid';
 import sinon from '@ciscospark/test-helper-sinon';
 
 const apiScope = filterScope('spark:kms', process.env.CISCOSPARK_SCOPE);
-
-const jwtSnooze = snoozeUntil('2018-01-16T00:00', 'JWT API methods are non-functional at this time');
 
 nodeOnly(describe)('plugin-authorization-node', () => {
   describe('Authorization', () => {
@@ -37,25 +35,30 @@ nodeOnly(describe)('plugin-authorization-node', () => {
     });
 
     describe('#requestAccessTokenFromJwt', () => {
-      jwtSnooze(it)('exchanges a JWT for an appid access token', () => createUser({subject: `test-${uuid.v4()}`})
-        .then(({jwt}) => {
-          const spark = new CiscoSpark();
-          return spark.authorization.requestAccessTokenFromJwt({jwt})
-            .then(() => assert.isTrue(spark.canAuthorize));
-        }));
+      it('exchanges a JWT for an appid access token', () => {
+        const userId = uuid.v4();
+        const displayName = `test-${userId}`;
+        return createUser({displayName, userId})
+          .then(({jwt}) => {
+            const spark = new CiscoSpark();
+            return spark.authorization.requestAccessTokenFromJwt({jwt})
+              .then(() => assert.isTrue(spark.canAuthorize));
+          });
+      });
     });
 
     describe('\'#refresh', () => {
       describe('when used with an appid access token', () => {
-        jwtSnooze(it)('refreshes the access token', () => {
-          const subject = `test-${uuid.v4()}`;
-          return createUser({subject})
+        it('refreshes the access token', () => {
+          const userId = uuid.v4();
+          const displayName = `test-${userId}`;
+          return createUser({displayName, userId})
             .then(({jwt}) => {
               const spark = new CiscoSpark({
                 config: {
                   credentials: {
                     jwtRefreshCallback() {
-                      return createUser({subject})
+                      return createUser({displayName, userId})
                         .then(({jwt}) => jwt);
                     }
                   }

--- a/packages/node_modules/@ciscospark/test-helper-appid/README.md
+++ b/packages/node_modules/@ciscospark/test-helper-appid/README.md
@@ -6,11 +6,11 @@ Test helper for creating App-ID users.
 
 ## `testHelperAppId.createUser(options)`
 
-Wrapper around router which will will make an API call from a web browser or directly invoke `jsonwebtoken` in node. Only require option is `subject`.
+Wrapper around router which will will make an API call from a web browser or directly invoke `jsonwebtoken` in node. Only required option is `displayName`.
 
 ## `testHelperAppId.router`
 
-Express router which will create a JWT from a POST request. Only required body parameter is `subject`. Use with
+Express router which will create a JWT from a POST request. Only required body parameter is `displayName`. Use with
 
 ```javascript
 app.use('/jwt', require('@ciscospark/test-helper-appid').router);

--- a/packages/node_modules/@ciscospark/test-helper-appid/src/create-user.js
+++ b/packages/node_modules/@ciscospark/test-helper-appid/src/create-user.js
@@ -2,13 +2,41 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-
 const jwt = require('jsonwebtoken');
+const uuid = require('uuid');
 
-module.exports = function createUser(options) {
-  return Promise.resolve({
-    jwt: jwt.sign({
-      org: process.env.CISCOSPARK_APPID_ORGID
-    }, Buffer.from(process.env.CISCOSPARK_APPID_SECRET, 'base64'), options)
-  });
+/**
+ * Creates a jwt user token
+ * @param {object} options
+ * @param {String} options.displayName *required*
+ * @param {Number} options.expiresInSeconds
+ * @param {String} options.issuer Guest Issuer ID
+ * @param {String} options.userId *no spaces*
+ * @returns {Promise<object>}
+ */
+module.exports = function createUser({
+  displayName,
+  expiresInSeconds,
+  issuer,
+  userId
+}) {
+  const payload = {
+    name: displayName
+  };
+  const options = {
+    expiresIn: expiresInSeconds || 90 * 60,
+    issuer: issuer || process.env.CISCOSPARK_APPID_ORGID,
+    subject: userId || uuid.v4()
+  };
+  const secret = Buffer.from(process.env.CISCOSPARK_APPID_SECRET, 'base64');
+  try {
+    const jwtToken = jwt.sign(payload, secret, options);
+    return Promise.resolve({
+      jwt: jwtToken,
+      secret: process.env.CISCOSPARK_APPID_SECRET
+    });
+  }
+  catch (e) {
+    return Promise.reject(e);
+  }
 };

--- a/packages/node_modules/@ciscospark/test-helper-appid/src/router.js
+++ b/packages/node_modules/@ciscospark/test-helper-appid/src/router.js
@@ -18,11 +18,11 @@ router.use(bodyParser.json({
 }));
 
 router.post('/', (req, res, next) => {
-  if (!req.body.subject) {
+  if (!req.body.displayName) {
     res
       .status(400)
       .json({
-        error: '`subject` is a required body parameter'
+        error: '`displayName` is a required body parameter'
       })
       .end();
     return;

--- a/tooling/lib/test/index.js
+++ b/tooling/lib/test/index.js
@@ -7,8 +7,8 @@ const debug = require('debug')('tooling:test');
 
 const dotenv = require('dotenv');
 
-dotenv.config({path: '.env.default'});
 dotenv.config();
+dotenv.config({path: '.env.default'});
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 
 const {

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -9,8 +9,8 @@ const path = require('path');
 const os = require('os');
 const webpackConfig = require('./webpack.config');
 
-dotenv.config({path: '.env.default'});
 dotenv.config();
+dotenv.config({path: '.env.default'});
 
 require('babel-register')({
   only: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,8 @@ const glob = require('glob');
 const path = require('path');
 const {EnvironmentPlugin} = require('webpack');
 
-dotenv.config({path: '.env.default'});
 dotenv.config();
+dotenv.config({path: '.env.default'});
 
 module.exports = {
   entry: './packages/node_modules/ciscospark',


### PR DESCRIPTION
# Add ability to provide more options to appid user

## Description

JWT generation was not using the parameters as documented on the [developer portal](https://developer.ciscospark.com/guest-issuer.html). These changes will allow us to match the style as well as gives some new options.

There was also an issue with `dotenv` importing order that has been resolved.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

