### PR TITLE
feat(@ciscospark/plugin-phone): add call:created event

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-phone/src/index.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/index.js
@@ -11,6 +11,7 @@ import Phone from './phone';
 import config from './config';
 
 export default Phone;
+export {events as phoneEvents} from './phone';
 export {default as Call} from './call';
 export {default as boolToStatus} from './bool-to-status';
 

--- a/packages/node_modules/@ciscospark/plugin-phone/src/phone.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/phone.js
@@ -7,8 +7,25 @@ import WebRTCMediaEngine from '@ciscospark/media-engine-webrtc';
 import {defaults, get} from 'lodash';
 
 import Call from './call';
-import {isCall, makeInternalCallId, shouldRing} from './state-parsers';
+import {isCall, shouldRing} from './state-parsers';
 import Calls from './calls';
+
+export const events = {
+  CALL_CREATED: 'call:created',
+  CALL_INCOMING: 'call:incoming'
+};
+
+/**
+ * Call Created Event
+ *
+ * Emitted when a call begins outside of the sdk
+ *
+ * @event call:created
+ * @instance
+ * @memberof Phone
+ * @type {Object}
+ * @property {Call} call The created call
+ */
 
 /**
  * Incoming Call Event
@@ -115,25 +132,13 @@ const Phone = SparkPlugin.extend({
           return Promise.resolve();
         }
         return Promise.all([
+          this.emittedCalls.reset(),
           this.spark.internal.mercury.when('event:mercury.buffer_state')
             .then(([message]) => {
               if (message.data.bufferState.locus === 'UNKNOWN') {
-                return this.spark.internal.locus.list();
+                return this.listActiveCalls();
               }
               return Promise.resolve();
-            })
-            .then((loci) => {
-              if (!loci) {
-                return;
-              }
-              // eslint-disable-next-line max-nested-callbacks
-              loci.forEach((locus) => {
-                this.trigger('call:incoming', Call.make({
-                  locus
-                }, {
-                  parent: this.spark
-                }));
-              });
             }),
           this.spark.internal.mercury.connect()
         ]);
@@ -189,11 +194,11 @@ const Phone = SparkPlugin.extend({
           return calls;
         }
         loci.forEach((locus) => {
-          if (!this.emittedCalls.get(makeInternalCallId(locus))) {
+          if (!this.emittedCalls.has(locus)) {
             const callItem = Call.make({locus, parent: this.spark});
             calls.push(callItem);
-            this.trigger('call:incoming', callItem);
             this.emittedCalls.add(callItem);
+            this._triggerCallEvents(callItem, locus);
           }
         });
         return calls;
@@ -239,21 +244,21 @@ const Phone = SparkPlugin.extend({
    * @returns {undefined}
    */
   onLocusEvent(event) {
-    if (shouldRing(event) && !this.emittedCalls.has(event.data.locus)) {
-      if (!get(this, 'config.enableExperimentalGroupCallingSupport') && !isCall(event.data.locus)) {
-        return;
-      }
-
-      const call = Call.make({
-        locus: event.data.locus
-      }, {
-        parent: this.spark
-      });
-
-      this.trigger('call:incoming', call);
-
-      this.emittedCalls.add(call);
+    // We only want to handle calls we are not aware of
+    if (this.emittedCalls.has(event.data.locus)) {
+      return;
     }
+
+    // Create call object and store in emittedCalls
+    const call = Call.make({
+      locus: event.data.locus
+    }, {
+      parent: this.spark
+    });
+    this.emittedCalls.add(call);
+
+    // Trigger events as necessary
+    this._triggerCallEvents(call, event.data.locus);
   },
 
   /**
@@ -276,6 +281,22 @@ const Phone = SparkPlugin.extend({
     call.dial(dialString, options);
     this.emittedCalls.add(call);
     return call;
+  },
+
+  /**
+   * Triggers call events for a given call/locus
+   * @param {Call} call
+   * @param {Types~Locus} locus
+   * @returns {undefined}
+   */
+  _triggerCallEvents(call, locus) {
+    this.trigger(events.CALL_CREATED, call);
+
+    if (shouldRing(locus)) {
+      if (isCall(locus) || (!isCall(locus) && get(this, 'config.enableExperimentalGroupCallingSupport'))) {
+        this.trigger(events.CALL_INCOMING, call);
+      }
+    }
   }
 });
 

--- a/packages/node_modules/@ciscospark/plugin-phone/src/state-parsers.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/state-parsers.js
@@ -284,13 +284,13 @@ export function remoteVideoMuted(participant) {
 
 /**
  * Indicates if the `call:incoming` event should be fired for the specified Locus
- * @param {Types~MercuryEvent} event Event which delivered the Locus
+ * @param {Types~Locus} locus Event which delivered the Locus
  * @param {ProxySpark} spark
  * @private
  * @returns {Boolean}
  */
-export function shouldRing(event) {
-  return get(event, 'data.locus.self.alertType.action') !== 'NONE';
+export function shouldRing(locus) {
+  return get(locus, 'self.alertType.action') !== 'NONE';
 }
 
 /**

--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/lib/event-expectations.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/lib/event-expectations.js
@@ -1,7 +1,12 @@
 import {expectEvent} from '@ciscospark/test-helper-mocha';
+import {phoneEvents} from '@ciscospark/plugin-phone';
+
+export function expectCallCreatedEvent(ctx, msg) {
+  return expectEvent(20000, phoneEvents.CALL_CREATED, ctx, msg);
+}
 
 export function expectCallIncomingEvent(ctx, msg) {
-  return expectEvent(20000, 'call:incoming', ctx, msg);
+  return expectEvent(20000, phoneEvents.CALL_INCOMING, ctx, msg);
 }
 
 export function expectChangeActiveParticipantsCountEvent(ctx, msg) {

--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/call.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/call.js
@@ -12,6 +12,7 @@ import {browserOnly, expectEvent, handleErrorEvent} from '@ciscospark/test-helpe
 import {base64} from '@ciscospark/common';
 
 import {
+  expectCallCreatedEvent,
   expectCallIncomingEvent,
   expectConnectedEvent,
   expectDisconnectedEvent,
@@ -207,7 +208,7 @@ browserOnly(describe)('plugin-phone', function () {
       ])
         .then(() => mccoy.spark.internal.mercury.disconnect())
         .then(() => Promise.all([
-          expectCallIncomingEvent(mccoy.spark.phone),
+          expectCallCreatedEvent(mccoy.spark.phone),
           mccoy.spark.phone.register()
         ]))
         .then(([mccoyCall]) => Promise.all([

--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/phone.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/phone.js
@@ -11,6 +11,7 @@ import testUsers from '@ciscospark/test-helper-test-users';
 import {browserOnly, handleErrorEvent} from '@ciscospark/test-helper-mocha';
 
 import {
+  expectCallCreatedEvent,
   expectCallIncomingEvent,
   expectChangeLocusEvent,
   expectConnectedEvent,
@@ -33,6 +34,12 @@ browserOnly(describe)('plugin-phone', function () {
       .then((users) => {
         [mccoy, spock] = users;
         spock.spark = new CiscoSpark({
+          credentials: {
+            authorization: spock.token
+          }
+        });
+
+        spock.spark2 = new CiscoSpark({
           credentials: {
             authorization: spock.token
           }
@@ -256,6 +263,31 @@ browserOnly(describe)('plugin-phone', function () {
             }));
       });
 
+      describe('when an incoming call is ringing', () => {
+        let incomingCall;
+        beforeEach('create an incoming call', () => handleErrorEvent(mccoy.spark.phone.dial(spock.email), () =>
+          expectCallIncomingEvent(spock.spark.phone, 'spock should receive an incoming call from mccoy')));
+
+        afterEach('hangup incoming call', () => incomingCall.hangup());
+
+        it('emits a call incoming event for an unanswered call', () => {
+          // Manually reset the emittedCalls collection
+          spock.spark.phone.emittedCalls.reset();
+          return Promise.all([
+            spock.spark.phone.listActiveCalls(),
+            expectCallIncomingEvent(spock.spark.phone, 'spock should emit an incoming call event')
+              .then((call) => {
+                incomingCall = call;
+              })
+          ])
+            .then(() => Promise.all([
+              // Answer the call so it can cleanup properly
+              incomingCall.answer(),
+              expectConnectedEvent(incomingCall)
+            ]));
+        });
+      });
+
       describe('when a ongoing call exists', () => {
         let connectedCall;
         beforeEach('create an existing call', () => handleErrorEvent(spock.spark.phone.dial(mccoy.email), (call) =>
@@ -288,7 +320,7 @@ browserOnly(describe)('plugin-phone', function () {
           return spock.spark.phone.listActiveCalls()
             .then((result) => {
               const activeCall = result[0];
-              assert.equal(spock.spark.phone.emittedCalls.length, 1, 'emitted calls collection should have one call');
+              assert.isAtLeast(spock.spark.phone.emittedCalls.length, 1, 'emitted calls collection should have at least one call');
               assert.isDefined(spock.spark.phone.emittedCalls.get(activeCall.internalCallId));
             });
         });
@@ -301,6 +333,14 @@ browserOnly(describe)('plugin-phone', function () {
               assert.equal(spock.spark.phone.emittedCalls.length, 1, 'emitted calls collection should have one call');
               assert.isDefined(spock.spark.phone.emittedCalls.get(activeCall.internalCallId));
             });
+        });
+
+        it('emits a call created event for the existing call', () => {
+          spock.spark.phone.emittedCalls.reset();
+          return Promise.all([
+            spock.spark.phone.listActiveCalls(),
+            expectCallCreatedEvent(spock.spark.phone)
+          ]);
         });
       });
     });
@@ -361,6 +401,18 @@ browserOnly(describe)('plugin-phone', function () {
         spock.spark.phone.dial(mccoy.email);
         return expectCallIncomingEvent(mccoy.spark.phone)
           .then(() => assert.calledOnce(ringMccoy));
+      });
+    });
+
+    describe('when a call is created elsewhere', () => {
+      it('emits a call:created event', () => {
+        const emittedCallsLength = spock.spark.phone.emittedCalls.length;
+        spock.spark2.phone.dial(mccoy.email);
+        return expectCallCreatedEvent(spock.spark.phone)
+          .then((createdCall) => {
+            assert.equal(spock.spark.phone.emittedCalls.length, emittedCallsLength + 1, 'emitted calls collection should have one additional call');
+            assert.isDefined(spock.spark.phone.emittedCalls.get(createdCall.internalCallId));
+          });
       });
     });
   });


### PR DESCRIPTION
A few things on this PR:

* A new phone event `call:created` was added
* Whenever a locus event happens to a call we aren't aware of via `emittedCalls`, the event will trigger
* Event names have been exported as an object `phoneEvents` to reduce the amount of "magic strings"
* Refactored the register locus listing to use the `listActiveCalls` method
* Expanded integration tests
