### PR TITLE
fix(internal-plugin-avatar): profile image orientation

### DIFF
--- a/packages/node_modules/@ciscospark/helper-image/package.json
+++ b/packages/node_modules/@ciscospark/helper-image/package.json
@@ -10,6 +10,10 @@
   "engines": {
     "node": ">=4"
   },
+  "browser": {
+    "./src/process-image.js": "./src/process-image.browser.js",
+    "./dist/process-image.js": "./dist/process-image.browser.js"
+  },
   "browserify": {
     "transform": [
       "babelify",

--- a/packages/node_modules/@ciscospark/helper-image/src/detect-filetype.js
+++ b/packages/node_modules/@ciscospark/helper-image/src/detect-filetype.js
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {detect} from '@ciscospark/http-core';
+import mime from 'mime-types';
+
+/**
+ * Determines the file type of the specified file
+ * @param {FileLike} file
+ * @param {Object} logger
+ * @returns {Promise<string>}
+ */
+export default function detectFileType(file, logger) {
+  if (file.type) {
+    logger.info(`file already has type ${file.type}. using existing file.type.`);
+    return Promise.resolve(file.type);
+  }
+
+  if (file.mimeType) {
+    logger.info(`file already has mimeType ${file.type}. using existing file.mimeType.`);
+    return Promise.resolve(file.mimeType);
+  }
+
+  // This kinda belongs in http core, but since we have no guarantee that
+  // buffers are expected to have names there, it'll stay here for now.
+  return detect(file)
+    .then((type) => {
+      if (type === 'application/x-msi' || type === 'application/octet-stream') {
+        logger.info(`detected filetype to be ${type}. Falling back to mime.lookup`);
+        return mime.lookup(file.name);
+      }
+
+      logger.info(`detected filetype to be ${type}. returning it`);
+      return type;
+    });
+}

--- a/packages/node_modules/@ciscospark/helper-image/src/index.js
+++ b/packages/node_modules/@ciscospark/helper-image/src/index.js
@@ -139,3 +139,6 @@ export function orient(options, file) {
   }
 }
 /* eslint-enable complexity */
+
+export {default as processImage} from './process-image';
+export {default as detectFileType} from './detect-filetype';

--- a/packages/node_modules/@ciscospark/helper-image/src/process-image.browser.js
+++ b/packages/node_modules/@ciscospark/helper-image/src/process-image.browser.js
@@ -3,7 +3,7 @@
  */
 
 import {pick} from 'lodash';
-import {orient} from '@ciscospark/helper-image';
+import {orient} from './index';
 /* eslint-env browser */
 
 /**
@@ -15,7 +15,7 @@ import {orient} from '@ciscospark/helper-image';
  * @param {Number} maxHeight
  * @returns {Object}
  */
-export function computeDimensions({width, height}, maxWidth, maxHeight) {
+function computeDimensions({width, height}, maxWidth, maxHeight) {
   if (height > width) {
     if (height > maxHeight) {
       width = width * maxHeight / height;
@@ -49,12 +49,14 @@ export function computeDimensions({width, height}, maxWidth, maxHeight) {
  * @param {Number} options.thumbnailMaxWidth
  * @param {Number} options.thumbnailMaxHeight
  * @param {Boolean} options.enableThumbnails
+ * @param {Object} options.logger
+ * @param {Boolean} options.isAvatar
  * @returns {Promise<Array>} Buffer, Dimensions, thumbnailDimensions
  */
 export default function processImage({
-  file, thumbnailMaxWidth, thumbnailMaxHeight, enableThumbnails
+  file, type, thumbnailMaxWidth, thumbnailMaxHeight, enableThumbnails, logger, isAvatar
 }) {
-  if (!file.type || !file.type.startsWith('image')) {
+  if (!type || !type.startsWith('image')) {
     return Promise.resolve();
   }
 
@@ -70,7 +72,14 @@ export default function processImage({
   })
     .then((img) => {
       const fileDimensions = pick(img, 'height', 'width');
+      if (isAvatar) { // only if image is a profile avatar
+        logger.info('dimensions will be set for avatar image');
+        const size = fileDimensions.height > fileDimensions.width ? fileDimensions.height : fileDimensions.width;
+        fileDimensions.height = size;
+        fileDimensions.width = size;
+      }
       if (!enableThumbnails) {
+        logger.info('thumbnails not enabled');
         return [null, fileDimensions, null];
       }
       const thumbnailDimensions = computeDimensions(fileDimensions, thumbnailMaxWidth, thumbnailMaxHeight);

--- a/packages/node_modules/@ciscospark/helper-image/src/process-image.js
+++ b/packages/node_modules/@ciscospark/helper-image/src/process-image.js
@@ -12,6 +12,7 @@ import {pick} from 'lodash';
  * @param {Number} options.thumbnailMaxWidth
  * @param {Number} options.thumbnailMaxHeight
  * @param {Boolean} options.enableThumbnails
+ * @param {Object} options.logger
  * @returns {Promise<Array>} Buffer, Dimensions, thumbnailDimensions
  */
 export default function processImage({

--- a/packages/node_modules/@ciscospark/internal-plugin-avatar/src/avatar.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-avatar/src/avatar.js
@@ -5,6 +5,7 @@
 import AvatarUrlBatcher from './avatar-url-batcher';
 import AvatarUrlStore from './avatar-url-store';
 import {oneFlight} from '@ciscospark/common';
+import {detectFileType, processImage} from '@ciscospark/helper-image';
 import {SparkPlugin} from '@ciscospark/spark-core';
 import {defaults} from 'lodash';
 
@@ -21,6 +22,10 @@ const Avatar = SparkPlugin.extend({
         return new AvatarUrlStore();
       },
       type: 'any'
+    },
+    enableThumbnails: {
+      default: true,
+      type: 'boolean'
     }
   },
 
@@ -64,7 +69,7 @@ const Avatar = SparkPlugin.extend({
    */
   retrieveAvatarUrl(user, options) {
     if (!user) {
-      return Promise.reject(new Error('`user` is a required parameter'));
+      return Promise.reject(new Error('\'user\' is a required parameter'));
     }
 
     options = defaults(options, {
@@ -89,35 +94,47 @@ const Avatar = SparkPlugin.extend({
    * @returns {Promise} Resolves with the URL of the full-sized avatar
    */
   setAvatar(file) {
-    return this.upload({
-      api: 'avatar',
-      resource: 'profile',
-      file,
-      phases: {
-        upload: {
-          $uri: function $uri(session) {
-            return session.url;
-          }
-        },
-        finalize: {
-          method: 'PUT',
-          api: 'avatar',
-          // eslint-disable-next-line no-unused-vars
-          $resource: function $resource(session) {
-            return `profile/${session.id}`;
+    return detectFileType(file, this.logger)
+      .then((type) => processImage({
+        file,
+        type,
+        thumbnailMaxWidth: this.config.thumbnailMaxWidth,
+        thumbnailMaxHeight: this.config.thumbnailMaxHeight,
+        enableThumbnails: this.enableThumbnails,
+        logger: this.logger,
+        isAvatar: true
+      }))
+      .then((file) => this.upload({
+        api: 'avatar',
+        resource: 'profile',
+        file: file[0],
+        phases: {
+          upload: {
+            $uri: function $uri(session) {
+              return session.url;
+            }
           },
-          $body: function $body(session) {
-            return session;
+          finalize: {
+            method: 'PUT',
+            api: 'avatar',
+            // eslint-disable-next-line no-unused-vars
+            $resource: function $resource(session) {
+              return `profile/${session.id}`;
+            },
+            $body: function $body(session) {
+              return session;
+            }
           }
         }
-      }
-    })
+      }))
       .then((res) => {
         // invalidate user's cached avatar
         this.store.remove({uuid: this.spark.internal.device.userId});
         return res.url;
       });
   }
+
 });
+
 
 export default Avatar;

--- a/packages/node_modules/@ciscospark/internal-plugin-avatar/src/config.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-avatar/src/config.js
@@ -18,6 +18,16 @@ export default {
      * @type {number}
      */
     defaultAvatarSize: 80,
-    sizes: [40, 50, 80, 110, 135, 192, 640, 1600]
+    sizes: [40, 50, 80, 110, 135, 192, 640, 1600],
+    /**
+     * Max height for thumbnails generated when sharing an image
+     * @type {number}
+     */
+    thumbnailMaxHeight: 960,
+    /**
+     * Max width for thumbnails generated when sharing an image
+     * @type {number}
+     */
+    thumbnailMaxWidth: 640
   }
 };

--- a/packages/node_modules/@ciscospark/internal-plugin-avatar/test/unit/spec/avatar.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-avatar/test/unit/spec/avatar.js
@@ -32,7 +32,7 @@ describe('plugin-avatar', () => {
 
   describe('#retrieveAvatarUrl()', () => {
     it('requires a user identifying object', () => Promise.all([
-      assert.isRejected(avatar.retrieveAvatarUrl(), '`user` is a required parameter')
+      assert.isRejected(avatar.retrieveAvatarUrl(), '\'user\' is a required parameter')
     ]));
 
     describe('when retrieving a single item', () => {

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/package.json
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/package.json
@@ -10,10 +10,6 @@
   "engines": {
     "node": ">=4"
   },
-  "browser": {
-    "./src/process-image.js": "./src/process-image.browser.js",
-    "./dist/process-image.js": "./dist/process-image.browser.js"
-  },
   "browserify": {
     "transform": [
       "babelify",

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/share-activity.js
@@ -5,12 +5,9 @@
 import {EventEmitter} from 'events';
 
 import {proxyEvents, transferEvents} from '@ciscospark/common';
-import {detect} from '@ciscospark/http-core';
 import {SparkPlugin} from '@ciscospark/spark-core';
 import {filter, map, pick, some} from 'lodash';
-import mime from 'mime-types';
-
-import processImage from './process-image';
+import {detectFileType, processImage} from '@ciscospark/helper-image';
 
 export const EMITTER_SYMBOL = Symbol('EMITTER_SYMBOL');
 export const FILE_SYMBOL = Symbol('FILE_SYMBOL');
@@ -114,7 +111,7 @@ const ShareActivity = SparkPlugin.extend({
     }, pick(options, 'actions'));
 
     this.uploads.set(file, upload);
-    const promise = this.detect(file)
+    const promise = detectFileType(file, this.logger)
       .then((type) => {
         upload.mimeType = type;
         return processImage({
@@ -169,36 +166,6 @@ const ShareActivity = SparkPlugin.extend({
 
     proxyEvents(emitter, promise);
     return promise;
-  },
-
-  /**
-   * Determines the file type of the specified file
-   * @param {FileLike} file
-   * @returns {Promise<string>}
-   */
-  detect(file) {
-    if (file.type) {
-      this.logger.info(`file already has type ${file.type}. using existing file.type.`);
-      return Promise.resolve(file.type);
-    }
-
-    if (file.mimeType) {
-      this.logger.info(`file already has mimeType ${file.type}. using existing file.mimeType.`);
-      return Promise.resolve(file.mimeType);
-    }
-
-    // This kinda belongs in http core, but since we have no guarantee that
-    // buffers are expected to have names there, it'll stay here for now.
-    return detect(file)
-      .then((type) => {
-        if (type === 'application/x-msi' || type === 'application/octet-stream') {
-          this.logger.info(`detected filetype to be ${type}. Falling back to mime.lookup`);
-          return mime.lookup(file.name);
-        }
-
-        this.logger.info(`detected filetype to be ${type}. returning it`);
-        return type;
-      });
   },
 
   /**


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes issue with the image orientation on profile avatars. The code for the same was earlier available as part of internal-plugin-conversation, but that is moved to helper-image so that the same code with minimal changes could be utilized for internal-plugin-avatar.

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-2864

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test images to reproduce and verify the existing bug could be referred from: https://github.com/recurser/exif-orientation-examples

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
