### PR TITLE
fix(i-p-presence): Batch subscription to max 50 ids

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-presence/src/presence.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-presence/src/presence.js
@@ -23,12 +23,16 @@ const Presence = SparkPlugin.extend({
    * @property {string} status: Current composed presence state
    * @property {string} statusTime: DateTime in RFC3339 format that the current status began
    * @property {string} lastActive: DateTime in RFC3339 format that the service last saw activity from the user.
-   * @property {string} expires: DEPRECATED - DateTime in RFC3339 format that represents when the current status will expire. Will not exist if expiresTTL is -1.
-   * @property {Number} expiresTTL: TTL in seconds until the status will expire. If TTL is -1 the current status has no known expiration.
-   * @property {string} expiresTime: DateTime in RFC3339 format that the current status will expire. Missing field means no known expiration.
+   * @property {string} expires: DEPRECATED - DateTime in RFC3339 format that represents when the current
+   * status will expire. Will not exist if expiresTTL is -1.
+   * @property {Number} expiresTTL: TTL in seconds until the status will expire. If TTL is -1 the current
+   * status has no known expiration.
+   * @property {string} expiresTime: DateTime in RFC3339 format that the current status will expire. Missing
+   * field means no known expiration.
    * @property {Object} vectorCounters: Used for packet ordering and tracking.
    * @property {Boolean} suppressNotifications: Indicates if notification suppresion is recommended for this status.
-   * @property {string} lastSeenDeviceUrl: Resource Identifier of the last device to post presence activity for this user.
+   * @property {string} lastSeenDeviceUrl: Resource Identifier of the last device to post presence activity for
+   * this user.
    */
 
   /**
@@ -81,6 +85,9 @@ const Presence = SparkPlugin.extend({
    */
   subscribe(personIds, subscriptionTtl = defaultSubscriptionTtl) {
     let subjects;
+    const batches = [];
+    const batchLimit = 50;
+
     if (!personIds) {
       return Promise.reject(new Error('A person id is required'));
     }
@@ -90,17 +97,24 @@ const Presence = SparkPlugin.extend({
     else {
       subjects = [personIds];
     }
-    return this.spark.request({
-      method: 'POST',
-      api: 'apheleia',
-      resource: 'subscriptions',
-      body: {
-        subjects,
-        subscriptionTtl,
-        includeStatus: true
-      }
-    })
-      .then((response) => response.body);
+    // Limit batches to 50 ids per request
+    for (let i = 0; i < subjects.length; i += batchLimit) {
+      batches.push(subjects.slice(i, i + batchLimit));
+    }
+
+    return Promise.all(batches.map((ids) =>
+      this.spark.request({
+        method: 'POST',
+        api: 'apheleia',
+        resource: 'subscriptions',
+        body: {
+          subjects: ids,
+          subscriptionTtl,
+          includeStatus: true
+        }
+      })
+        .then((response) => response.body.responses)))
+      .then((idBatches) => ({responses: [].concat(...idBatches)}));
   },
 
   /**

--- a/packages/node_modules/@ciscospark/internal-plugin-presence/test/unit/spec/presence.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-presence/test/unit/spec/presence.js
@@ -3,6 +3,7 @@
  */
 
 import {assert} from '@ciscospark/test-helper-chai';
+import sinon from '@ciscospark/test-helper-sinon';
 import Presence from '@ciscospark/internal-plugin-presence';
 import MockSpark from '@ciscospark/test-helper-mock-spark';
 
@@ -30,6 +31,20 @@ describe('plugin-presence', () => {
 
     describe('#subscribe()', () => {
       it('requires a person parameter', () => assert.isRejected(spark.internal.presence.subscribe(), /A person id is required/));
+      it('subscription request called twice with batch of 100 ids', () => {
+        const ids = [...Array(100).keys()];
+        spark.request = function (options) {
+          return Promise.resolve({
+            statusCode: 204,
+            body: [],
+            options
+          });
+        };
+        sinon.spy(spark, 'request');
+
+        spark.internal.presence.subscribe(ids);
+        assert.calledTwice(spark.request);
+      });
     });
 
     describe('#unsubscribe()', () => {


### PR DESCRIPTION
## Description

Add process to split subscription requests of more than 50 user ids into separate requests to match service request max.

Fixes [SSDK-1812](https://jira-eng-gpk2.cisco.com/jira/browse/SSDK-1812)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* SDK Version: 1.30.0
* Node/Browser Version: 8.9.4
* NPM Version: 5.7.1

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
