### PR TITLE
test(i-p-wdm): fix incorrect speechServicesManager name

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/ping.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/ping.js
@@ -67,7 +67,7 @@ describe('plugin-wdm', function () {
        */
       const unreachableServices = [
         'mercuryAlternateDC',
-        'speechServicesManagerUrl',
+        'speechServicesManager',
         'stickies'
       ];
 


### PR DESCRIPTION
The services are stripped of the `url` in their listing. It started failing recently because they changed the allowed CORS to the service.