### PR TITLE
chore(bin-sauce-connect): update sc version to 4.4.8

### DIFF
--- a/packages/node_modules/@ciscospark/bin-sauce-connect/src/start.js
+++ b/packages/node_modules/@ciscospark/bin-sauce-connect/src/start.js
@@ -11,7 +11,7 @@ const exists = require('./lib/exists');
 const spawn = require('./lib/spawn');
 const rm = require('./lib/rm');
 
-const SAUCE_CONNECT_VERSION = '4.4.2';
+const SAUCE_CONNECT_VERSION = '4.4.8';
 
 if (exists(pidFile)) {
   console.log('Sauce Connect already connected');


### PR DESCRIPTION
The current version of sauce connect no longer works and needs to be updated.