### PR TITLE
Issue 872 - conversations and teams not respecting high availability host substitutions

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -811,6 +811,7 @@ const Conversation = SparkPlugin.extend({
         return this.spark.internal.device.getServiceUrl('conversation')
           .then((url) => {
             conversation.url = `${url}/conversations/${conversation.id}`;
+            return conversation;
           });
       }
       else if (!conversation.url) {

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -803,18 +803,28 @@ const Conversation = SparkPlugin.extend({
    * @returns {Promise}
    */
   _inferConversationUrl(conversation) {
-    if (!conversation.url && conversation.id) {
-      return this.spark.internal.device.getServiceUrl('conversation')
-        .then((url) => {
-          conversation.url = `${url}/conversations/${conversation.id}`;
-          /* istanbul ignore else */
-          if (process.env.NODE_ENV !== 'production') {
-            this.logger.warn('conversation: inferred conversation url from conversation id; please pass whole conversation objects to Conversation methods');
-          }
-          return conversation;
-        });
+    if (conversation.id) {
+      const feature = this.features.developer.get('web-ha-messaging');
+      if (feature && feature.value) {
+        // recompute conversation URL each time as the host may have changed
+        // since last usage
+        return this.spark.internal.device.getServiceUrl('conversation')
+          .then((url) => {
+            conversation.url = `${url}/conversations/${conversation.id}`;
+          });
+      }
+      else if (!conversation.url) {
+        return this.spark.internal.device.getServiceUrl('conversation')
+          .then((url) => {
+            conversation.url = `${url}/conversations/${conversation.id}`;
+            /* istanbul ignore else */
+            if (process.env.NODE_ENV !== 'production') {
+              this.logger.warn('conversation: inferred conversation url from conversation id; please pass whole conversation objects to Conversation methods');
+            }
+            return conversation;
+          });
+      }
     }
-
     return Promise.resolve(conversation);
   },
 

--- a/packages/node_modules/@ciscospark/internal-plugin-team/src/team.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-team/src/team.js
@@ -268,18 +268,28 @@ const Team = SparkPlugin.extend({
   },
 
   _inferTeamUrl(team) {
-    if (!team.url && team.id) {
-      return this.spark.internal.device.getServiceUrl('conversation')
-        .then((url) => {
-          team.url = `${url}/teams/${team.id}`;
-          /* istanbul ignore else */
-          if (process.env.NODE_ENV !== 'production') {
-            this.logger.warn('team: inferred team url from conversation id; please pass whole team objects to Team methods');
-          }
-          return team;
-        });
+    if (team.id) {
+      const feature = this.features.developer.get('web-ha-messaging');
+      if (feature && feature.value) {
+        // recompute team URL each time as the host may have changed since last usage
+        return this.spark.internal.device.getServiceUrl('conversation')
+          .then((url) => {
+            team.url = `${url}/teams/${team.id}`;
+            return team;
+          });
+      }
+      else if (!team.url) {
+        return this.spark.internal.device.getServiceUrl('conversation')
+          .then((url) => {
+            team.url = `${url}/teams/${team.id}`;
+            /* istanbul ignore else */
+            if (process.env.NODE_ENV !== 'production') {
+              this.logger.warn('team: inferred team url from conversation id; please pass whole team objects to Team methods');
+            }
+            return team;
+          });
+      }
     }
-
     return Promise.resolve(team);
   },
 


### PR DESCRIPTION
# Pull Request Template

## Description
i-p-conversation and i-p-team were using a cached version of their endpoint URLs, ignoring any high availability host changes and causing authentication issues as requests were routed to different services.

Fixes #872 

## Type of Change
HA dependent changes (toggle must be enabled for changes to take effect) ensure the endpoint url is
computed with each usage.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Existing non-ha conversation unit tests
- [ ] Existing non-ha team unit tests

**Test Configuration**:
* SDK Version 1.30.x
* Node/Browser Version 8
* NPM Version 7.3

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
